### PR TITLE
#218: Update javadoc to Jakarta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -26,7 +26,7 @@
     <artifactId>jakarta.persistence-api</artifactId>
     <version>2.2.2-SNAPSHOT</version>
 
-    <description>Jakarta Persistence</description>
+    <name>Jakarta Persistence API</name>
     <url>https://github.com/eclipse-ee4j/jpa-api</url>
 
     <scm>
@@ -230,7 +230,7 @@
                 <configuration>
                     <instructions>
                         <Automatic-Module-Name>java.persistence</Automatic-Module-Name>
-                        <Bundle-Description>Java(TM) Persistence ${spec.specification.version} API jar</Bundle-Description>
+                        <Bundle-Description>Jakarta Persistence ${spec.specification.version} API jar</Bundle-Description>
                         <Bundle-Name>Jakarta Persistence API jar</Bundle-Name>
                         <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
                         <Bundle-Version>${spec.bundle.version}</Bundle-Version>
@@ -266,8 +266,9 @@
                 <configuration>
                     <doclint>all</doclint>
                     <bottom><![CDATA[<br>
-Copyright &#169; {inceptionYear}&#x2013;{currentYear} Oracle and/or its affiliates.
-All rights reserved.<br>Comments to: <a href="mailto:jpa-dev@eclipse.org">jpa-dev@eclipse.org</a>.]]>
+Comments to: <a href="mailto:jpa-dev@eclipse.org">jpa-dev@eclipse.org</a>.<br>
+Copyright &#169; {inceptionYear}&#x2013;{currentYear} Oracle and/or its affiliates. All rights reserved.<br>
+Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                     </bottom>
                 </configuration>
             </plugin>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -69,8 +69,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <version>[1.8,)</version>
+                                    <message>You need JDK8 or newer</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/src/main/java/javax/persistence/Access.java
+++ b/src/main/java/javax/persistence/Access.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  * mapped superclass, or embeddable class, or to a specific attribute
  * of such a class.
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { TYPE, METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/AccessType.java
+++ b/src/main/java/javax/persistence/AccessType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ package javax.persistence;
  * 
  * @see Access
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum AccessType {
 

--- a/src/main/java/javax/persistence/AssociationOverride.java
+++ b/src/main/java/javax/persistence/AssociationOverride.java
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.0 - Version 2.0 (October 1 - 2013)
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.0 - Version 2.0 (October 1 - 2013)
 //     Specification available from https://projects.eclipse.org/projects/ee4j.jpa
 
 package javax.persistence;
@@ -123,7 +123,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see MappedSuperclass
  * @see AttributeOverride
  *
- * @since Java Persistence 1.0 
+ * @since 1.0 
  */
 @Repeatable(AssociationOverrides.class)
 @Target({TYPE, METHOD, FIELD}) 
@@ -159,7 +159,7 @@ public @interface AssociationOverride {
      *   persistence provider's default foreign key strategy will
      *   apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 
@@ -171,7 +171,7 @@ public @interface AssociationOverride {
      * if a foreign key mapping is used in the overriding of
      * the relationship.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     JoinTable joinTable() default @JoinTable;
 }

--- a/src/main/java/javax/persistence/AssociationOverrides.java
+++ b/src/main/java/javax/persistence/AssociationOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -61,7 +61,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  *@see AssociationOverride
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE, METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/AttributeConverter.java
+++ b/src/main/java/javax/persistence/AttributeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 

--- a/src/main/java/javax/persistence/AttributeNode.java
+++ b/src/main/java/javax/persistence/AttributeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -26,7 +26,7 @@ import java.util.Map;
  * @see Subgraph
  * @see NamedAttributeNode
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface AttributeNode<T> {
 

--- a/src/main/java/javax/persistence/AttributeOverride.java
+++ b/src/main/java/javax/persistence/AttributeOverride.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -133,7 +133,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see MappedSuperclass
  * @see AssociationOverride
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(AttributeOverrides.class)
 @Target({TYPE, METHOD, FIELD}) 

--- a/src/main/java/javax/persistence/AttributeOverrides.java
+++ b/src/main/java/javax/persistence/AttributeOverrides.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -44,7 +44,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see AttributeOverride
  *
- * @since Java Persistence 1.0 
+ * @since 1.0 
  */
 @Target({TYPE, METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Basic.java
+++ b/src/main/java/javax/persistence/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -56,7 +56,7 @@ import static javax.persistence.FetchType.EAGER;
  *    protected String getName() { return name; }
  *
  * </pre>
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Cache.java
+++ b/src/main/java/javax/persistence/Cache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -21,7 +21,7 @@ package javax.persistence;
  * If a cache is not in use, the methods of this interface have
  * no effect, except for <code>contains</code>, which returns false.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Cache {
 
@@ -63,7 +63,7 @@ public interface Cache {
      * @return an instance of the specified class
      * @throws PersistenceException if the provider does not
      * support the call
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public <T> T unwrap(Class<T> cls);
 }

--- a/src/main/java/javax/persistence/CacheRetrieveMode.java
+++ b/src/main/java/javax/persistence/CacheRetrieveMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * specify the behavior when data is retrieved by the
  * <code>find</code> methods and by queries.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum CacheRetrieveMode {
 

--- a/src/main/java/javax/persistence/CacheStoreMode.java
+++ b/src/main/java/javax/persistence/CacheStoreMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * the behavior when data is read from the database and when data is
  * committed into the database.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum CacheStoreMode {
 

--- a/src/main/java/javax/persistence/Cacheable.java
+++ b/src/main/java/javax/persistence/Cacheable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * <p> <code>Cacheable(false)</code> means that the entity and its state must 
  * not be cached by the provider.
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { TYPE })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/CascadeType.java
+++ b/src/main/java/javax/persistence/CascadeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * The value <code>cascade=ALL</code> is equivalent to 
  * <code>cascade={PERSIST, MERGE, REMOVE, REFRESH, DETACH}</code>.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum CascadeType { 
 
@@ -44,7 +44,7 @@ public enum CascadeType {
     /**
      * Cascade detach operation
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      * 
      */   
     DETACH

--- a/src/main/java/javax/persistence/CollectionTable.java
+++ b/src/main/java/javax/persistence/CollectionTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -98,7 +98,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see AssociationOverride
  * @see Column
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 
 @Target( { METHOD, FIELD })
@@ -152,7 +152,7 @@ public @interface CollectionTable {
      *   persistence provider's default foreign key strategy will
      *   apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 
@@ -166,7 +166,7 @@ public @interface CollectionTable {
      * (Optional) Indexes for the table.  These are only used if
      * table generation is in effect. 
      *
-     * @since Java Persistence 2.1 
+     * @since 2.1 
      */
     Index[] indexes() default {};
 }

--- a/src/main/java/javax/persistence/Column.java
+++ b/src/main/java/javax/persistence/Column.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * </pre></blockquote>
  *
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */ 
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/ColumnResult.java
+++ b/src/main/java/javax/persistence/ColumnResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -55,7 +55,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see SqlResultSetMapping
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)
@@ -69,7 +69,7 @@ public @interface ColumnResult {
      *  (Optional) The Java type to which the column type is to be mapped.
      *  If the <code>type</code> element is not specified, the default JDBC type 
      *  mapping for the column will be used.
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     Class type() default void.class;
 }

--- a/src/main/java/javax/persistence/ConstraintMode.java
+++ b/src/main/java/javax/persistence/ConstraintMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,14 +11,14 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
 /**
  * Used to control the application of a constraint.
  * 
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public enum ConstraintMode {
 

--- a/src/main/java/javax/persistence/ConstructorResult.java
+++ b/src/main/java/javax/persistence/ConstructorResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -64,7 +64,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see SqlResultSetMapping
  * @see ColumnResult
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Convert.java
+++ b/src/main/java/javax/persistence/Convert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -182,7 +182,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *  @see Converts
  *  @see Basic
  *
- *  @since Java Persistence 2.1
+ *  @since 2.1
  */
 @Repeatable(Converts.class)
 @Target({METHOD, FIELD, TYPE}) @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Converter.java
+++ b/src/main/java/javax/persistence/Converter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -58,7 +58,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see AttributeConverter
  * @see Convert
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({TYPE}) @Retention(RUNTIME)
 public @interface Converter {

--- a/src/main/java/javax/persistence/Converts.java
+++ b/src/main/java/javax/persistence/Converts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * must not be applied to the same basic attribute.
  *
  * @see Convert
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({METHOD, FIELD, TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/DiscriminatorColumn.java
+++ b/src/main/java/javax/persistence/DiscriminatorColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -51,7 +51,7 @@ import static javax.persistence.DiscriminatorType.STRING;
  *
  * @see DiscriminatorValue
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/DiscriminatorType.java
+++ b/src/main/java/javax/persistence/DiscriminatorType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,15 +11,15 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
 /**
  * Defines supported types of the discriminator column. 
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum DiscriminatorType { 
 

--- a/src/main/java/javax/persistence/DiscriminatorValue.java
+++ b/src/main/java/javax/persistence/DiscriminatorValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -60,7 +60,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see DiscriminatorColumn
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/ElementCollection.java
+++ b/src/main/java/javax/persistence/ElementCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -42,7 +42,7 @@ import static javax.persistence.FetchType.LAZY;
  *    } 
  *  </pre>
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Embeddable.java
+++ b/src/main/java/javax/persistence/Embeddable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -72,7 +72,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Documented
 @Target({TYPE}) 

--- a/src/main/java/javax/persistence/Embedded.java
+++ b/src/main/java/javax/persistence/Embedded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see AssociationOverride
  * @see AssociationOverrides
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/EmbeddedId.java
+++ b/src/main/java/javax/persistence/EmbeddedId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -74,7 +74,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see Embeddable
  * @see MapsId
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Entity.java
+++ b/src/main/java/javax/persistence/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Specifies that the class is an entity. This annotation is applied to the
  * entity class.
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Documented
 @Target(TYPE)
@@ -37,7 +37,7 @@ public @interface Entity {
 	 * (Optional) The entity name. Defaults to the unqualified
 	 * name of the entity class. This name is used to refer to the
 	 * entity in queries. The name must not be a reserved literal
-	 * in the Java Persistence query language.
+	 * in the Jakarta Persistence query language.
 	 */
 	String name() default "";
 }

--- a/src/main/java/javax/persistence/EntityExistsException.java
+++ b/src/main/java/javax/persistence/EntityExistsException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -30,7 +30,7 @@ package javax.persistence;
  *
  * @see javax.persistence.EntityManager#persist(Object)
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class EntityExistsException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/EntityGraph.java
+++ b/src/main/java/javax/persistence/EntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -34,7 +34,7 @@ import java.util.List;
  * @see Subgraph
  * @see NamedEntityGraph
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface EntityGraph<T> {
 

--- a/src/main/java/javax/persistence/EntityListeners.java
+++ b/src/main/java/javax/persistence/EntityListeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * entity or mapped superclass. This annotation may be applied 
  * to an entity class or mapped superclass.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/EntityManager.java
+++ b/src/main/java/javax/persistence/EntityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -49,7 +49,7 @@ import javax.persistence.criteria.CriteriaDelete;
  * @see PersistenceContext
  * @see StoredProcedureQuery
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface EntityManager {
 
@@ -127,7 +127,7 @@ public interface EntityManager {
      *         not denote an entity type or the second argument is
      *         is not a valid type for that entity's primary key or 
      *         is null 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */ 
     public <T> T find(Class<T> entityClass, Object primaryKey, 
                       Map<String, Object> properties); 
@@ -174,7 +174,7 @@ public interface EntityManager {
      *         only the statement is rolled back
      * @throws PersistenceException if an unsupported lock call 
      *         is made
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> T find(Class<T> entityClass, Object primaryKey,
                       LockModeType lockMode);
@@ -229,7 +229,7 @@ public interface EntityManager {
      *         only the statement is rolled back
      * @throws PersistenceException if an unsupported lock call 
      *         is made
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> T find(Class<T> entityClass, Object primaryKey,
                       LockModeType lockMode, 
@@ -362,7 +362,7 @@ public interface EntityManager {
      *         only the statement is rolled back
      * @throws PersistenceException if an unsupported lock call 
      *         is made
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public void lock(Object entity, LockModeType lockMode,
                      Map<String, Object> properties);
@@ -397,7 +397,7 @@ public interface EntityManager {
      *         entity manager of type <code>PersistenceContextType.TRANSACTION</code>
      * @throws EntityNotFoundException if the entity no longer 
      *         exists in the database 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */     
     public void refresh(Object entity,
                             Map<String, Object> properties); 
@@ -435,7 +435,7 @@ public interface EntityManager {
      *         only the statement is rolled back
      * @throws PersistenceException if an unsupported lock call
      *         is made
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public void refresh(Object entity, LockModeType lockMode);
 
@@ -480,7 +480,7 @@ public interface EntityManager {
      *         only the statement is rolled back
      * @throws PersistenceException if an unsupported lock call
      *         is made
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public void refresh(Object entity, LockModeType lockMode,
                         Map<String, Object> properties);
@@ -503,7 +503,7 @@ public interface EntityManager {
      * @param entity  entity instance
      * @throws IllegalArgumentException if the instance is not an 
      *         entity 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public void detach(Object entity); 
 
@@ -525,7 +525,7 @@ public interface EntityManager {
      *         joined to the current transaction
      * @throws IllegalArgumentException if the instance is not a
      *         managed entity and a transaction is active
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public LockModeType getLockMode(Object entity);
 
@@ -537,7 +537,7 @@ public interface EntityManager {
      * @param value  value for property or hint
      * @throws IllegalArgumentException if the second argument is 
      *         not valid for the implementation 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */ 
     public void setProperty(String propertyName, Object value);
 
@@ -546,14 +546,14 @@ public interface EntityManager {
      * for the entity manager. Changing the contents of the map does 
      * not change the configuration in effect.
      * @return map of properties and hints in effect for entity manager
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public Map<String, Object> getProperties();
 
     /**
      * Create an instance of <code>Query</code> for executing a
-     * Java Persistence query language statement.
-     * @param qlString a Java Persistence query string
+     * Jakarta Persistence query language statement.
+     * @param qlString a Jakarta Persistence query string
      * @return the new query instance
      * @throws IllegalArgumentException if the query string is
      *         found to be invalid
@@ -567,7 +567,7 @@ public interface EntityManager {
      * @return the new query instance
      * @throws IllegalArgumentException if the criteria query is
      *         found to be invalid
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> TypedQuery<T> createQuery(CriteriaQuery<T> criteriaQuery); 
 
@@ -578,7 +578,7 @@ public interface EntityManager {
      * @return the new query instance
      * @throws IllegalArgumentException if the update query is
      *         found to be invalid
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public Query createQuery(CriteriaUpdate updateQuery);
 
@@ -589,29 +589,29 @@ public interface EntityManager {
      * @return the new query instance
      * @throws IllegalArgumentException if the delete query is
      *         found to be invalid
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public Query createQuery(CriteriaDelete deleteQuery);
 
     /**
      * Create an instance of <code>TypedQuery</code> for executing a
-     * Java Persistence query language statement.
+     * Jakarta Persistence query language statement.
      * The select list of the query must contain only a single
      * item, which must be assignable to the type specified by
      * the <code>resultClass</code> argument.
-     * @param qlString a Java Persistence query string
+     * @param qlString a Jakarta Persistence query string
      * @param resultClass the type of the query result
      * @return the new query instance
      * @throws IllegalArgumentException if the query string is found
      *         to be invalid or if the query result is found to
      *         not be assignable to the specified type
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> TypedQuery<T> createQuery(String qlString, Class<T> resultClass);
 
     /**
      * Create an instance of <code>Query</code> for executing a named query
-     * (in the Java Persistence query language or in native SQL).
+     * (in the Jakarta Persistence query language or in native SQL).
      * @param name the name of a query defined in metadata
      * @return the new query instance
      * @throws IllegalArgumentException if a query has not been
@@ -622,7 +622,7 @@ public interface EntityManager {
 
     /**
      * Create an instance of <code>TypedQuery</code> for executing a
-     * Java Persistence query language named query.
+     * Jakarta Persistence query language named query.
      * The select list of the query must contain only a single
      * item, which must be assignable to the type specified by
      * the <code>resultClass</code> argument.
@@ -633,7 +633,7 @@ public interface EntityManager {
      *         defined with the given name or if the query string is
      *         found to be invalid or if the query result is found to
      *         not be assignable to the specified type
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> TypedQuery<T> createNamedQuery(String name, Class<T> resultClass);
 
@@ -682,7 +682,7 @@ public interface EntityManager {
      * @return the new stored procedure query instance
      * @throws IllegalArgumentException if a query has not been
      * defined with the given name
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public StoredProcedureQuery createNamedStoredProcedureQuery(String name);
 
@@ -699,7 +699,7 @@ public interface EntityManager {
      * @throws IllegalArgumentException if a stored procedure of the
      * given name does not exist (or the query execution will
      * fail)
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public StoredProcedureQuery createStoredProcedureQuery(String procedureName);
 
@@ -720,7 +720,7 @@ public interface EntityManager {
      * @throws IllegalArgumentException if a stored procedure of the
      * given name does not exist (or the query execution will
      * fail)
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public StoredProcedureQuery createStoredProcedureQuery(
 	       String procedureName, Class... resultClasses);
@@ -765,7 +765,7 @@ public interface EntityManager {
      * is not joined to the current transaction or if no
      * transaction is active
      * @return boolean
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public boolean isJoinedToTransaction();
 
@@ -780,7 +780,7 @@ public interface EntityManager {
      * @return an instance of the specified class
      * @throws PersistenceException if the provider does not 
      *         support the call 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public <T> T unwrap(Class<T> cls); 
 
@@ -831,7 +831,7 @@ public interface EntityManager {
      * @return EntityManagerFactory instance
      * @throws IllegalStateException if the entity manager has 
      *         been closed
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public EntityManagerFactory getEntityManagerFactory();
 
@@ -841,7 +841,7 @@ public interface EntityManager {
      * @return CriteriaBuilder instance
      * @throws IllegalStateException if the entity manager has
      *         been closed
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public CriteriaBuilder getCriteriaBuilder();
 
@@ -851,7 +851,7 @@ public interface EntityManager {
      * @return Metamodel instance
      * @throws IllegalStateException if the entity manager has
      *         been closed
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public Metamodel getMetamodel();
 
@@ -860,7 +860,7 @@ public interface EntityManager {
      * EntityGraph.
      * @param rootType class of entity graph
      * @return entity graph
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public <T> EntityGraph<T> createEntityGraph(Class<T> rootType);
 
@@ -869,7 +869,7 @@ public interface EntityManager {
      * is no entity graph with the specified name, null is returned.
      * @param graphName name of an entity graph
      * @return entity graph
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public EntityGraph<?> createEntityGraph(String graphName);
 
@@ -880,7 +880,7 @@ public interface EntityManager {
      * @return named entity graph
      * @throws IllegalArgumentException if there is no EntityGraph of
      *         the given name
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public  EntityGraph<?> getEntityGraph(String graphName);
 
@@ -890,7 +890,7 @@ public interface EntityManager {
      * @param entityClass  entity class
      * @return list of all entity graphs defined for the entity
      * @throws IllegalArgumentException if the class is not an entity
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public <T> List<EntityGraph<? super T>> getEntityGraphs(Class<T> entityClass);
 

--- a/src/main/java/javax/persistence/EntityManagerFactory.java
+++ b/src/main/java/javax/persistence/EntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -30,7 +30,7 @@ import javax.persistence.criteria.CriteriaBuilder;
  * <code>EntityManagerFactory</code> has been closed, all its entity managers
  * are considered to be in the closed state.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface EntityManagerFactory {
 
@@ -70,7 +70,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory
      * has been configured for resource-local entity managers or is closed
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public EntityManager createEntityManager(SynchronizationType synchronizationType);
 
@@ -87,7 +87,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory
      * has been configured for resource-local entity managers or is closed
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public EntityManager createEntityManager(SynchronizationType synchronizationType, Map map);
 
@@ -98,7 +98,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory 
      * has been closed
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public CriteriaBuilder getCriteriaBuilder();
     
@@ -109,7 +109,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory
      * has been closed
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public Metamodel getMetamodel();
 
@@ -140,7 +140,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory 
      * has been closed
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public Map<String, Object> getProperties();
 
@@ -152,7 +152,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory
      * has been closed
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public Cache getCache();
 
@@ -163,7 +163,7 @@ public interface EntityManagerFactory {
      * @throws IllegalStateException if the entity manager factory
      * has been closed
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public PersistenceUnitUtil getPersistenceUnitUtil();
 
@@ -192,7 +192,7 @@ public interface EntityManagerFactory {
      * @param name name for the query
      * @param query Query, TypedQuery, or StoredProcedureQuery object
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public void addNamedQuery(String name, Query query);
 
@@ -207,7 +207,7 @@ public interface EntityManagerFactory {
      * @return an instance of the specified class
      * @throws PersistenceException if the provider does not
      * support the call
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public <T> T unwrap(Class<T> cls);
 
@@ -217,7 +217,7 @@ public interface EntityManagerFactory {
      * already exists, it is replaced.
      * @param graphName  name for the entity graph
      * @param entityGraph  entity graph
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public <T> void addNamedEntityGraph(String graphName, EntityGraph<T> entityGraph);
 

--- a/src/main/java/javax/persistence/EntityNotFoundException.java
+++ b/src/main/java/javax/persistence/EntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -36,7 +36,7 @@ package javax.persistence;
  * @see EntityManager#lock(Object, LockModeType)
  * @see EntityManager#lock(Object, LockModeType, java.util.Map)
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class EntityNotFoundException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/EntityResult.java
+++ b/src/main/java/javax/persistence/EntityResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -47,7 +47,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see SqlResultSetMapping
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/EntityTransaction.java
+++ b/src/main/java/javax/persistence/EntityTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ package javax.persistence;
  * <code>EntityTransaction</code> interface.
 
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface EntityTransaction {
 

--- a/src/main/java/javax/persistence/EnumType.java
+++ b/src/main/java/javax/persistence/EnumType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -21,7 +21,7 @@ package javax.persistence;
  * enumerated type specify how a persistent property or
  * field of an enumerated type should be persisted.
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum EnumType {
     /** Persist enumerated type property or field as an integer. */

--- a/src/main/java/javax/persistence/Enumerated.java
+++ b/src/main/java/javax/persistence/Enumerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -52,7 +52,7 @@ import static javax.persistence.EnumType.ORDINAL;
  * @see Basic
  * @see ElementCollection
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/ExcludeDefaultListeners.java
+++ b/src/main/java/javax/persistence/ExcludeDefaultListeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * to be excluded for the entity class (or mapped superclass) 
  * and its subclasses.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/ExcludeSuperclassListeners.java
+++ b/src/main/java/javax/persistence/ExcludeSuperclassListeners.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * to be excluded for the entity class (or mapped superclass) 
  * and its subclasses.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/FetchType.java
+++ b/src/main/java/javax/persistence/FetchType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -39,7 +39,7 @@ package javax.persistence;
  * @see OneToMany
  * @see ManyToOne
  * @see OneToOne
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum FetchType {
 

--- a/src/main/java/javax/persistence/FieldResult.java
+++ b/src/main/java/javax/persistence/FieldResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -47,7 +47,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see EntityResult
  * @see SqlResultSetMapping
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/FlushModeType.java
+++ b/src/main/java/javax/persistence/FlushModeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -39,7 +39,7 @@ package javax.persistence;
  * joined to the current transaction, the persistence provider must not flush 
  * to the database.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum FlushModeType {
 

--- a/src/main/java/javax/persistence/ForeignKey.java
+++ b/src/main/java/javax/persistence/ForeignKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -56,7 +56,7 @@ import static javax.persistence.ConstraintMode.CONSTRAINT;
  * @see SecondaryTable
  * @see AssociationOverride
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/GeneratedValue.java
+++ b/src/main/java/javax/persistence/GeneratedValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -56,7 +56,7 @@ import static javax.persistence.GenerationType.AUTO;
  * @see TableGenerator
  * @see SequenceGenerator
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/GenerationType.java
+++ b/src/main/java/javax/persistence/GenerationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -21,7 +21,7 @@ package javax.persistence;
  *
  * @see GeneratedValue
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum GenerationType { 
 

--- a/src/main/java/javax/persistence/Id.java
+++ b/src/main/java/javax/persistence/Id.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -48,7 +48,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see Column
  * @see GeneratedValue
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/IdClass.java
+++ b/src/main/java/javax/persistence/IdClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *   }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Index.java
+++ b/src/main/java/javax/persistence/Index.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -43,7 +43,7 @@ import java.lang.annotation.Target;
  * @see JoinTable
  * @see TableGenerator
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  *
  */
 @Target({})

--- a/src/main/java/javax/persistence/Inheritance.java
+++ b/src/main/java/javax/persistence/Inheritance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -41,7 +41,7 @@ import static javax.persistence.InheritanceType.SINGLE_TABLE;
  *   public class ValuedCustomer extends Customer { ... }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/InheritanceType.java
+++ b/src/main/java/javax/persistence/InheritanceType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,15 +11,15 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
 /**
  * Defines inheritance strategy options.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum InheritanceType { 
 

--- a/src/main/java/javax/persistence/JoinColumn.java
+++ b/src/main/java/javax/persistence/JoinColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -54,7 +54,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see CollectionTable
  * @see ForeignKey
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(JoinColumns.class)
 @Target({METHOD, FIELD})
@@ -180,7 +180,7 @@ public @interface JoinColumn {
      *  this element is not specified, the persistence provider's
      *  default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 }

--- a/src/main/java/javax/persistence/JoinColumns.java
+++ b/src/main/java/javax/persistence/JoinColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -45,7 +45,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see JoinColumn
  * @see ForeignKey
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)
@@ -65,7 +65,7 @@ public @interface JoinColumns {
      *  is specified in either location, the persistence provider's
      *  default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 }

--- a/src/main/java/javax/persistence/JoinTable.java
+++ b/src/main/java/javax/persistence/JoinTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -60,7 +60,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see JoinColumn
  * @see JoinColumns
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)
@@ -119,7 +119,7 @@ public @interface JoinTable {
      *   persistence provider's default foreign key strategy will
      *   apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 
@@ -134,7 +134,7 @@ public @interface JoinTable {
      *  is specified in either location, the persistence provider's
      *  default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey inverseForeignKey() default @ForeignKey(PROVIDER_DEFAULT);
 
@@ -150,7 +150,7 @@ public @interface JoinTable {
      * (Optional) Indexes for the table.  These are only used if
      * table generation is in effect. 
      *
-     * @since Java Persistence 2.1 
+     * @since 2.1 
      */
     Index[] indexes() default {};
 }

--- a/src/main/java/javax/persistence/Lob.java
+++ b/src/main/java/javax/persistence/Lob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -55,7 +55,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see Basic
  * @see ElementCollection
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/LockModeType.java
+++ b/src/main/java/javax/persistence/LockModeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -123,7 +123,7 @@ package javax.persistence;
  * throw the {@link LockTimeoutException} (and must not mark the transaction
  * for rollback).
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  *
  */
 public enum LockModeType
@@ -147,14 +147,14 @@ public enum LockModeType
     /**
      * Optimistic lock.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     OPTIMISTIC,
 
     /**
      * Optimistic lock, with version update.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     OPTIMISTIC_FORCE_INCREMENT,
 
@@ -162,28 +162,28 @@ public enum LockModeType
      *
      * Pessimistic read lock.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     PESSIMISTIC_READ,
 
     /**
      * Pessimistic write lock.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     PESSIMISTIC_WRITE,
 
     /**
      * Pessimistic write lock, with version update.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     PESSIMISTIC_FORCE_INCREMENT,
 
     /**
      * No lock.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     NONE
 }

--- a/src/main/java/javax/persistence/LockTimeoutException.java
+++ b/src/main/java/javax/persistence/LockTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ package javax.persistence;
  * commit time. The current transaction, if one is active, will be not
  * be marked for rollback.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public class LockTimeoutException extends PersistenceException {
     /** The object that caused the exception */

--- a/src/main/java/javax/persistence/ManyToMany.java
+++ b/src/main/java/javax/persistence/ManyToMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -99,7 +99,7 @@ import static javax.persistence.FetchType.LAZY;
  *
  * @see JoinTable
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/ManyToOne.java
+++ b/src/main/java/javax/persistence/ManyToOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -78,7 +78,7 @@ import static javax.persistence.FetchType.EAGER;
  *
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/MapKey.java
+++ b/src/main/java/javax/persistence/MapKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -80,7 +80,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/MapKeyClass.java
+++ b/src/main/java/javax/persistence/MapKeyClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -89,7 +89,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see ElementCollection 
  * @see OneToMany
  * @see ManyToMany
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 
 @Target( { METHOD, FIELD })

--- a/src/main/java/javax/persistence/MapKeyColumn.java
+++ b/src/main/java/javax/persistence/MapKeyColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -44,7 +44,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *       ...
  *    } 
  * </pre>
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/MapKeyEnumerated.java
+++ b/src/main/java/javax/persistence/MapKeyEnumerated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -56,7 +56,7 @@ import static javax.persistence.EnumType.ORDINAL;
  * @see OneToMany
  * @see ManyToMany
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target({METHOD, FIELD}) @Retention(RUNTIME)
 public @interface MapKeyEnumerated {

--- a/src/main/java/javax/persistence/MapKeyJoinColumn.java
+++ b/src/main/java/javax/persistence/MapKeyJoinColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -90,7 +90,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  *
  * @see ForeignKey
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Repeatable(MapKeyJoinColumns.class)
 @Target( { METHOD, FIELD })
@@ -192,7 +192,7 @@ public @interface MapKeyJoinColumn {
          *  this element is not specified, the persistence provider's
          *  default foreign key strategy will apply.
          *
-         *  @since Java Persistence 2.1
+         *  @since 2.1
          */
         ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 }

--- a/src/main/java/javax/persistence/MapKeyJoinColumns.java
+++ b/src/main/java/javax/persistence/MapKeyJoinColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -35,7 +35,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see MapKeyJoinColumn
  * @see ForeignKey
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)
@@ -56,7 +56,7 @@ public @interface MapKeyJoinColumns {
          *  location, the persistence provider's default foreign key
          *  strategy will apply.
          *
-         *  @since Java Persistence 2.1
+         *  @since 2.1
          */
         ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 }

--- a/src/main/java/javax/persistence/MapKeyTemporal.java
+++ b/src/main/java/javax/persistence/MapKeyTemporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     protected java.util.Map&#060;java.util.Date, Employee&#062; employees;
  * </pre>
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/MappedSuperclass.java
+++ b/src/main/java/javax/persistence/MappedSuperclass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -93,7 +93,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see AttributeOverride 
  * @see AssociationOverride
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Documented
 @Target({TYPE})

--- a/src/main/java/javax/persistence/MapsId.java
+++ b/src/main/java/javax/persistence/MapsId.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -62,7 +62,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    }
  * </pre>
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/NamedAttributeNode.java
+++ b/src/main/java/javax/persistence/NamedAttributeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 
 package javax.persistence;
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see NamedEntityGraph
  * @see NamedSubgraph
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/NamedEntityGraph.java
+++ b/src/main/java/javax/persistence/NamedEntityGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Used to specify the path and boundaries for a find operation or query.
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Repeatable(NamedEntityGraphs.class)
 @Target({TYPE})

--- a/src/main/java/javax/persistence/NamedEntityGraphs.java
+++ b/src/main/java/javax/persistence/NamedEntityGraphs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 
 package javax.persistence;
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Used to group <code>NamedEntityGraph</code> annotations.  
  *
  * @see NamedEntityGraph
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/NamedNativeQueries.java
+++ b/src/main/java/javax/persistence/NamedNativeQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence; 
 
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see NamedNativeQuery
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/NamedNativeQuery.java
+++ b/src/main/java/javax/persistence/NamedNativeQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -29,7 +29,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * The <code>NamedNativeQuery</code> annotation can be applied to an 
  * entity or mapped superclass.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(NamedNativeQueries.class)
 @Target({TYPE}) 

--- a/src/main/java/javax/persistence/NamedQueries.java
+++ b/src/main/java/javax/persistence/NamedQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence; 
 
@@ -22,13 +22,13 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Specifies multiple named Java Persistence query language queries.
+ * Specifies multiple named Jakarta Persistence query language queries.
  * Query names are scoped to the persistence unit.
  * The <code>NamedQueries</code> annotation can be applied to an entity or mapped superclass.
  *
  * @see NamedQuery
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE})  
 @Retention(RUNTIME) 

--- a/src/main/java/javax/persistence/NamedQuery.java
+++ b/src/main/java/javax/persistence/NamedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -25,12 +25,12 @@ import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /** 
- * Specifies a static, named query in the Java Persistence query language.
+ * Specifies a static, named query in the Jakarta Persistence query language.
  * Query names are scoped to the persistence unit.
  * The <code>NamedQuery</code> annotation can be applied to an entity or mapped superclass.
  *
  * <p> The following is an example of the definition of a named query 
- * in the Java Persistence query language:
+ * in the Jakarta Persistence query language:
  *
  * <pre>
  *    &#064;NamedQuery(
@@ -50,7 +50,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *            .getResultList();
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(NamedQueries.class)
 @Target({TYPE}) 
@@ -64,7 +64,7 @@ public @interface NamedQuery {
     String name();
 
     /** (Required) 
-     * The query string in the Java Persistence query language. 
+     * The query string in the Jakarta Persistence query language.
      */
     String query();
 
@@ -72,7 +72,7 @@ public @interface NamedQuery {
      * (Optional) The lock mode type to use in query execution.  If a <code>lockMode</code>
      * other than <code>LockModeType.NONE</code> is specified, the query must be executed in
      * a transaction and the persistence context joined to the transaction.
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     LockModeType lockMode() default NONE;
     

--- a/src/main/java/javax/persistence/NamedStoredProcedureQueries.java
+++ b/src/main/java/javax/persistence/NamedStoredProcedureQueries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence; 
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see NamedStoredProcedureQuery
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/NamedStoredProcedureQuery.java
+++ b/src/main/java/javax/persistence/NamedStoredProcedureQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
 
 
 package javax.persistence;
@@ -68,7 +68,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see StoredProcedureQuery
  * @see StoredProcedureParameter
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Repeatable(NamedStoredProcedureQueries.class)
 @Target({TYPE}) 

--- a/src/main/java/javax/persistence/NamedSubgraph.java
+++ b/src/main/java/javax/persistence/NamedSubgraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -30,7 +30,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see NamedEntityGraph
  * @see NamedAttributeNode
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({})
 @Retention(RUNTIME)
@@ -57,5 +57,3 @@ public @interface NamedSubgraph {
      */
     NamedAttributeNode[] attributeNodes();
 }
-
-

--- a/src/main/java/javax/persistence/NoResultException.java
+++ b/src/main/java/javax/persistence/NoResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ package javax.persistence;
  * @see Query#getSingleResult()
  * @see TypedQuery#getSingleResult()
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class NoResultException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/NonUniqueResultException.java
+++ b/src/main/java/javax/persistence/NonUniqueResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ package javax.persistence;
  * @see Query#getSingleResult()
  * @see TypedQuery#getSingleResult()
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class NonUniqueResultException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/OneToMany.java
+++ b/src/main/java/javax/persistence/OneToMany.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -84,7 +84,7 @@ import static javax.persistence.FetchType.LAZY;
  *    
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)
@@ -131,7 +131,7 @@ public @interface OneToMany {
      * (Optional) Whether to apply the remove operation to entities that have
      * been removed from the relationship and to cascade the remove operation to
      * those entities.
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     boolean orphanRemoval() default false;
 }

--- a/src/main/java/javax/persistence/OneToOne.java
+++ b/src/main/java/javax/persistence/OneToOne.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -109,7 +109,7 @@ import static javax.persistence.FetchType.EAGER;
  *
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)
@@ -159,7 +159,7 @@ public @interface OneToOne {
      * (Optional) Whether to apply the remove operation to entities that have
      * been removed from the relationship and to cascade the remove operation to
      * those entities.
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     boolean orphanRemoval() default false;
 }

--- a/src/main/java/javax/persistence/OptimisticLockException.java
+++ b/src/main/java/javax/persistence/OptimisticLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ package javax.persistence;
  * @see EntityManager#lock(Object, LockModeType)
  * @see EntityManager#lock(Object, LockModeType, java.util.Map)
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class OptimisticLockException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/OrderBy.java
+++ b/src/main/java/javax/persistence/OrderBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -113,7 +113,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see OrderColumn
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/OrderColumn.java
+++ b/src/main/java/javax/persistence/OrderColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -66,7 +66,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @see OrderBy
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Parameter.java
+++ b/src/main/java/javax/persistence/Parameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ package javax.persistence;
  * @see Query
  * @see TypedQuery
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Parameter<T> {
 
@@ -50,7 +50,7 @@ public interface Parameter<T> {
      * not be portable.
      * @return the Java type of the parameter
      * @throws IllegalStateException if invoked on a parameter
-     *         obtained from a Java persistence query language 
+     *         obtained from a query language 
      *         query or native query when the implementation does 
      *         not support this use
      */

--- a/src/main/java/javax/persistence/ParameterMode.java
+++ b/src/main/java/javax/persistence/ParameterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence; 
 
@@ -21,7 +21,7 @@ package javax.persistence;
  * @see StoredProcedureQuery
  * @see StoredProcedureParameter
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public enum ParameterMode {
 

--- a/src/main/java/javax/persistence/Persistence.java
+++ b/src/main/java/javax/persistence/Persistence.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -30,15 +30,15 @@ import javax.persistence.spi.LoadState;
  * in Java SE environments.  It may also be used to cause schema
  * generation to occur.
  * 
- * <p> The <code>Persistence</code> class is available in a Java EE
+ * <p> The <code>Persistence</code> class is available in a Jakarta EE
  * container environment as well; however, support for the Java SE
  * bootstrapping APIs is not required in container environments.
  * 
  * <p> The <code>Persistence</code> class is used to obtain a {@link
  * javax.persistence.PersistenceUtil PersistenceUtil} instance in both
- * Java EE and Java SE environments.
+ * Jakarta EE and Java SE environments.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class Persistence {
     
@@ -105,7 +105,7 @@ public class Persistence {
      *         configuration information is provided or if schema
      *         generation otherwise fails.
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public static void generateSchema(String persistenceUnitName, Map map) {
         PersistenceProviderResolver resolver = PersistenceProviderResolverHolder.getPersistenceProviderResolver();
@@ -124,7 +124,7 @@ public class Persistence {
     /**
      * Return the PersistenceUtil instance
      * @return PersistenceUtil instance
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public static PersistenceUtil getPersistenceUtil() {
        return new PersistenceUtilImpl();
@@ -133,7 +133,7 @@ public class Persistence {
     
     /**
      * Implementation of PersistenceUtil interface
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     private static class PersistenceUtilImpl implements PersistenceUtil {
         public boolean isLoaded(Object entity, String attributeName) {
@@ -184,7 +184,7 @@ public class Persistence {
 
     /**
      * This final String is deprecated and should be removed and is only here for TCK backward compatibility
-     * @since Java Persistence 1.0
+     * @since 1.0
      * @deprecated
      */
     @Deprecated
@@ -192,7 +192,7 @@ public class Persistence {
     
     /**
      * This instance variable is deprecated and should be removed and is only here for TCK backward compatibility
-     * @since Java Persistence 1.0
+     * @since 1.0
      * @deprecated
      */
     @Deprecated

--- a/src/main/java/javax/persistence/PersistenceContext.java
+++ b/src/main/java/javax/persistence/PersistenceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * Expresses a dependency on a container-managed {@link EntityManager} and its
  * associated persistence context.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 
 @Repeatable(PersistenceContexts.class)
@@ -63,7 +63,7 @@ public @interface PersistenceContext {
      * the persistence context must be explicitly joined to the current
      * transaction by means of the EntityManager 
      * {@link EntityManager#joinTransaction joinTransaction} method.
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     SynchronizationType synchronization() default SynchronizationType.SYNCHRONIZED;
 

--- a/src/main/java/javax/persistence/PersistenceContextType.java
+++ b/src/main/java/javax/persistence/PersistenceContextType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -21,7 +21,7 @@ package javax.persistence;
  * persistence context is to be used in {@link PersistenceContext}. 
  * If not specified, a transaction-scoped persistence context is used.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum PersistenceContextType {
 

--- a/src/main/java/javax/persistence/PersistenceContexts.java
+++ b/src/main/java/javax/persistence/PersistenceContexts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  *
  *@see PersistenceContext
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PersistenceException.java
+++ b/src/main/java/javax/persistence/PersistenceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -26,7 +26,7 @@ package javax.persistence;
  * the current transaction, if one is active and the persistence context has
  * been joined to it, to be marked for rollback.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class PersistenceException extends RuntimeException {
 

--- a/src/main/java/javax/persistence/PersistenceProperty.java
+++ b/src/main/java/javax/persistence/PersistenceProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -29,7 +29,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * container when the entity manager is created. Properties that 
  * are not recognized by a vendor will be ignored.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PersistenceUnit.java
+++ b/src/main/java/javax/persistence/PersistenceUnit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.*;
  * Expresses a dependency on an {@link EntityManagerFactory} and its
  * associated persistence unit.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(PersistenceUnits.class)
 @Target({TYPE, METHOD, FIELD})

--- a/src/main/java/javax/persistence/PersistenceUnitUtil.java
+++ b/src/main/java/javax/persistence/PersistenceUnitUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -24,7 +24,7 @@ package javax.persistence;
  * instances obtained from or managed by entity managers for this
  * persistence unit or on new entity instances.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface PersistenceUnitUtil extends PersistenceUtil {
 

--- a/src/main/java/javax/persistence/PersistenceUnits.java
+++ b/src/main/java/javax/persistence/PersistenceUnits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -25,7 +25,7 @@ import static java.lang.annotation.RetentionPolicy.*;
 /**
  * Declares one or more {@link PersistenceUnit} annotations.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 
 @Target({TYPE})

--- a/src/main/java/javax/persistence/PersistenceUtil.java
+++ b/src/main/java/javax/persistence/PersistenceUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -26,7 +26,7 @@ package javax.persistence;
  * entity or entity attribute regardless of which persistence 
  * provider in the environment created the entity.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface PersistenceUtil {
 

--- a/src/main/java/javax/persistence/PessimisticLockException.java
+++ b/src/main/java/javax/persistence/PessimisticLockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * commit time. The current transaction, if one is active, will be marked for 
  * rollback.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public class PessimisticLockException extends PersistenceException {
     /** The object that caused the exception */

--- a/src/main/java/javax/persistence/PessimisticLockScope.java
+++ b/src/main/java/javax/persistence/PessimisticLockScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -24,7 +24,7 @@ package javax.persistence;
  * allow lock modes to be specified or used with the
  * {@link NamedQuery} annotation.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum PessimisticLockScope {
 

--- a/src/main/java/javax/persistence/PostLoad.java
+++ b/src/main/java/javax/persistence/PostLoad.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PostPersist.java
+++ b/src/main/java/javax/persistence/PostPersist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PostRemove.java
+++ b/src/main/java/javax/persistence/PostRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PostUpdate.java
+++ b/src/main/java/javax/persistence/PostUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PrePersist.java
+++ b/src/main/java/javax/persistence/PrePersist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -28,7 +28,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PreRemove.java
+++ b/src/main/java/javax/persistence/PreRemove.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PreUpdate.java
+++ b/src/main/java/javax/persistence/PreUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * of an entity class, a mapped superclass, or a callback 
  * listener class.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/PrimaryKeyJoinColumn.java
+++ b/src/main/java/javax/persistence/PrimaryKeyJoinColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -66,7 +66,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  * @see OneToOne
  * @see ForeignKey
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(PrimaryKeyJoinColumns.class)
 @Target({TYPE, METHOD, FIELD})
@@ -113,7 +113,7 @@ public @interface PrimaryKeyJoinColumn {
      *  this element is not specified, the persistence provider's
      *  default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 }

--- a/src/main/java/javax/persistence/PrimaryKeyJoinColumns.java
+++ b/src/main/java/javax/persistence/PrimaryKeyJoinColumns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -45,7 +45,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  *
  * @see ForeignKey
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE, METHOD, FIELD})
 @Retention(RUNTIME)
@@ -64,7 +64,7 @@ public @interface PrimaryKeyJoinColumns {
      *  is specified in either location, the persistence provider's
      *  default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 

--- a/src/main/java/javax/persistence/Query.java
+++ b/src/main/java/javax/persistence/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Lukas Jungmann  - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -31,7 +31,7 @@ import java.util.stream.Stream;
  * @see StoredProcedureQuery
  * @see Parameter
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface Query {
 
@@ -142,7 +142,7 @@ public interface Query {
      * retrieve. Returns <code>Integer.MAX_VALUE</code> if <code>setMaxResults</code> was not
      * applied to the query object.
      * @return maximum number of results
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     int getMaxResults();
 
@@ -160,7 +160,7 @@ public interface Query {
      * retrieve. Returns 0 if <code>setFirstResult</code> was not applied to the
      * query object.
      * @return position of the first result
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     int getFirstResult();
 
@@ -185,7 +185,7 @@ public interface Query {
      * Get the properties and hints and associated values that are 
      * in effect for the query instance.
      * @return query properties and hints
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Map<String, Object> getHints();
 
@@ -197,7 +197,7 @@ public interface Query {
      * @throws IllegalArgumentException if the parameter
      *         does not correspond to a parameter of the
      *         query
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     <T> Query setParameter(Parameter<T> param, T value);
 
@@ -209,7 +209,7 @@ public interface Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Query setParameter(Parameter<Calendar> param, Calendar value, 
                        TemporalType temporalType);
@@ -222,7 +222,7 @@ public interface Query {
      * @return the same query instance
      * @throws IllegalArgumentException if the parameter does not
      *         correspond to a parameter of the query
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Query setParameter(Parameter<Date> param, Date value, 
                        TemporalType temporalType);
@@ -312,7 +312,7 @@ public interface Query {
      * @throws IllegalStateException if invoked on a native
      *         query when the implementation does not support 
      *         this use
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Set<Parameter<?>> getParameters();
 
@@ -328,7 +328,7 @@ public interface Query {
      * @throws IllegalStateException if invoked on a native
      *         query when the implementation does not support 
      *         this use
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Parameter<?> getParameter(String name);
 
@@ -344,9 +344,9 @@ public interface Query {
      *         specified name does not exist or is not assignable
      *         to the type
      * @throws IllegalStateException if invoked on a native
-     *         query or Java Persistence query language query when
+     *         query or Jakarta Persistence query language query when
      *         the implementation does not support this use
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     <T> Parameter<T> getParameter(String name, Class<T> type);
 
@@ -362,7 +362,7 @@ public interface Query {
      * @throws IllegalStateException if invoked on a native
      *         query when the implementation does not support 
      *         this use
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Parameter<?> getParameter(int position);
 
@@ -377,9 +377,9 @@ public interface Query {
      *         specified position does not exist or is not assignable
      *         to the type
      * @throws IllegalStateException if invoked on a native
-     *         query or Java Persistence query language query when
+     *         query or Jakarta Persistence query language query when
      *         the implementation does not support this use
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     <T> Parameter<T> getParameter(int position, Class<T> type);
 
@@ -388,7 +388,7 @@ public interface Query {
      * to the parameter.
      * @param param parameter object
      * @return boolean indicating whether parameter has been bound
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     boolean isBound(Parameter<?> param);
 
@@ -401,7 +401,7 @@ public interface Query {
      *         a parameter of the query
      * @throws IllegalStateException if the parameter has not been
      *         been bound
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     <T> T getParameterValue(Parameter<T> param);
 
@@ -414,7 +414,7 @@ public interface Query {
      *         been bound
      * @throws IllegalArgumentException if the parameter of the
      *         specified name does not exist
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Object getParameterValue(String name);
 
@@ -427,7 +427,7 @@ public interface Query {
      *         been bound
      * @throws IllegalArgumentException if the parameter with the
      *         specified position does not exist
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Object getParameterValue(int position);
 
@@ -445,7 +445,7 @@ public interface Query {
      * If a flush mode has not been set for the query object, 
      * returns the flush mode in effect for the entity manager.
      * @return flush mode
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     FlushModeType getFlushMode();
 
@@ -454,9 +454,9 @@ public interface Query {
      * @param lockMode  lock mode
      * @return the same query instance
      * @throws IllegalStateException if the query is found not to be 
-     *         a Java Persistence query language SELECT query
+     *         a Jakarta Persistence query language SELECT query
      *         or a CriteriaQuery query
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     Query setLockMode(LockModeType lockMode);
 
@@ -465,9 +465,9 @@ public interface Query {
      * mode has not been set on the query object.
      * @return lock mode
      * @throws IllegalStateException if the query is found not to be
-     *         a Java Persistence query language SELECT query or
+     *         a Jakarta Persistence query language SELECT query or
      *         a Criteria API query
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     LockModeType getLockMode();
 
@@ -483,7 +483,7 @@ public interface Query {
      * @return an instance of the specified class
      * @throws PersistenceException if the provider does not support
      *         the call
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     <T> T unwrap(Class<T> cls);
 }

--- a/src/main/java/javax/persistence/QueryHint.java
+++ b/src/main/java/javax/persistence/QueryHint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * <p> Vendor-specific hints that are not recognized by a provider are ignored.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/QueryTimeoutException.java
+++ b/src/main/java/javax/persistence/QueryTimeoutException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * The current transaction, if one is active, will be not
  * be marked for rollback.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public class QueryTimeoutException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/RollbackException.java
+++ b/src/main/java/javax/persistence/RollbackException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 /**
@@ -21,7 +21,7 @@ package javax.persistence;
  *
  * @see javax.persistence.EntityTransaction#commit()
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class RollbackException extends PersistenceException {
 	

--- a/src/main/java/javax/persistence/SecondaryTable.java
+++ b/src/main/java/javax/persistence/SecondaryTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -58,7 +58,7 @@ import static javax.persistence.ConstraintMode.PROVIDER_DEFAULT;
  *    public class Customer { ... }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(SecondaryTables.class)
 @Target(TYPE) 
@@ -98,7 +98,7 @@ public @interface SecondaryTable {
      *   is specified in either location, the persistence provider's
      *   default foreign key strategy will apply.
      *
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ForeignKey foreignKey() default @ForeignKey(PROVIDER_DEFAULT);
 
@@ -116,7 +116,7 @@ public @interface SecondaryTable {
      * (Optional) Indexes for the table.  These are only used if
      * table generation is in effect. 
      *
-     * @since Java Persistence 2.1 
+     * @since 2.1
      */
     Index[] indexes() default {};
 }

--- a/src/main/java/javax/persistence/SecondaryTables.java
+++ b/src/main/java/javax/persistence/SecondaryTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    public class Employee { ... }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target(TYPE) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/SequenceGenerator.java
+++ b/src/main/java/javax/persistence/SequenceGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Lukas Jungmann  - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -40,7 +40,7 @@ import java.lang.annotation.Repeatable;
  *   &#064;SequenceGenerator(name="EMP_SEQ", allocationSize=25)
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(SequenceGenerators.class)
 @Target({TYPE, METHOD, FIELD}) 
@@ -63,13 +63,13 @@ public @interface SequenceGenerator {
 
     /** (Optional) The catalog of the sequence generator. 
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     String catalog() default "";
 
     /** (Optional) The schema of the sequence generator. 
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     String schema() default "";
 

--- a/src/main/java/javax/persistence/SequenceGenerators.java
+++ b/src/main/java/javax/persistence/SequenceGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
+//     Lukas Jungmann  - 2.2
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Used to group <code>SequenceGenerator</code> annotations.
  *
  * @see SequenceGenerator
- * @since Java Persistence 2.2
+ * @since 2.2
  */
 @Target({TYPE, METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/SharedCacheMode.java
+++ b/src/main/java/javax/persistence/SharedCacheMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -22,7 +22,7 @@ package javax.persistence;
  * <code>shared-cache-mode</code> element, and returned as the result of
  * {@link javax.persistence.spi.PersistenceUnitInfo#getSharedCacheMode()}.
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum SharedCacheMode {
 

--- a/src/main/java/javax/persistence/SqlResultSetMapping.java
+++ b/src/main/java/javax/persistence/SqlResultSetMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Petros Splinakis - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Petros Splinakis - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -55,7 +55,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see NamedNativeQuery
  * @see NamedStoredProcedureQuery
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(SqlResultSetMappings.class)
 @Target({TYPE}) 
@@ -74,7 +74,7 @@ public @interface SqlResultSetMapping {
 
     /** 
      * Specifies the result set mapping to constructors. 
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     ConstructorResult[] classes() default {};
 

--- a/src/main/java/javax/persistence/SqlResultSetMappings.java
+++ b/src/main/java/javax/persistence/SqlResultSetMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -24,7 +24,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * Is used to define one or more {@link SqlResultSetMapping} annotations.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({TYPE}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/StoredProcedureParameter.java
+++ b/src/main/java/javax/persistence/StoredProcedureParameter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence; 
 
@@ -26,7 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @see NamedStoredProcedureQuery
  * @see ParameterMode 
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 @Target({}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/StoredProcedureQuery.java
+++ b/src/main/java/javax/persistence/StoredProcedureQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -97,7 +97,7 @@ import java.util.List;
  * @see Query
  * @see Parameter
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface StoredProcedureQuery extends Query {
 

--- a/src/main/java/javax/persistence/Subgraph.java
+++ b/src/main/java/javax/persistence/Subgraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -29,7 +29,7 @@ import java.util.List;
  * @see AttributeNode
  * @see NamedSubgraph
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface Subgraph<T> {
 

--- a/src/main/java/javax/persistence/SynchronizationType.java
+++ b/src/main/java/javax/persistence/SynchronizationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence;
 
@@ -21,7 +21,7 @@ package javax.persistence;
  * must be explicitly joined to the current transaction by means of the
  * {@link EntityManager#joinTransaction} method.
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public enum SynchronizationType {
 

--- a/src/main/java/javax/persistence/Table.java
+++ b/src/main/java/javax/persistence/Table.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -37,7 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    public class Customer { ... }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target(TYPE) 
 @Retention(RUNTIME)
@@ -75,7 +75,7 @@ public @interface Table {
      * to specify an index for a primary key, as the primary key
      * index will be created automatically.
      *
-     * @since Java Persistence 2.1 
+     * @since 2.1
      */
     Index[] indexes() default {};
 }

--- a/src/main/java/javax/persistence/TableGenerator.java
+++ b/src/main/java/javax/persistence/TableGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Lukas Jungmann  - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -72,7 +72,7 @@ import java.lang.annotation.Repeatable;
  *
  * @see GeneratedValue
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Repeatable(TableGenerators.class)
 @Target({TYPE, METHOD, FIELD}) 
@@ -148,7 +148,7 @@ public @interface TableGenerator {
      * to specify an index for a primary key, as the primary key
      * index will be created automatically.
      *
-     * @since Java Persistence 2.1 
+     * @since 2.1 
      */
     Index[] indexes() default {};
 }

--- a/src/main/java/javax/persistence/TableGenerators.java
+++ b/src/main/java/javax/persistence/TableGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
+//     Lukas Jungmann  - 2.2
 
 package javax.persistence;
 
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * Used to group <code>TableGenerator</code> annotations.
  *
  * @see TableGenerator
- * @since Java Persistence 2.2
+ * @since 2.2
  */
 @Target({TYPE, METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Temporal.java
+++ b/src/main/java/javax/persistence/Temporal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *     protected java.util.Date endDate;
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD}) 
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/TemporalType.java
+++ b/src/main/java/javax/persistence/TemporalType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -20,7 +20,7 @@ package javax.persistence;
  * Type used to indicate a specific mapping of <code>java.util.Date</code> 
  * or <code>java.util.Calendar</code>.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum TemporalType {
 

--- a/src/main/java/javax/persistence/TransactionRequiredException.java
+++ b/src/main/java/javax/persistence/TransactionRequiredException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence;
@@ -21,7 +21,7 @@ package javax.persistence;
  * Thrown by the persistence provider when a transaction is required but is not
  * active.
  * 
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public class TransactionRequiredException extends PersistenceException {
 

--- a/src/main/java/javax/persistence/Transient.java
+++ b/src/main/java/javax/persistence/Transient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -38,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/Tuple.java
+++ b/src/main/java/javax/persistence/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * @see TupleElement
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Tuple {
 

--- a/src/main/java/javax/persistence/TupleElement.java
+++ b/src/main/java/javax/persistence/TupleElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -23,7 +23,7 @@ package javax.persistence;
  *
  * @see Tuple
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface TupleElement<X> {
     

--- a/src/main/java/javax/persistence/TypedQuery.java
+++ b/src/main/java/javax/persistence/TypedQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Lukas Jungmann  - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * @see Query
  * @see Parameter
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface TypedQuery<X> extends Query {
 	
@@ -270,7 +270,7 @@ public interface TypedQuery<X> extends Query {
       * @param lockMode  lock mode
       * @return the same query instance
       * @throws IllegalStateException if the query is found not to 
-      *         be a Java Persistence query language SELECT query
+      *         be a Jakarta Persistence query language SELECT query
       *         or a CriteriaQuery query
       */
      TypedQuery<X> setLockMode(LockModeType lockMode);

--- a/src/main/java/javax/persistence/UniqueConstraint.java
+++ b/src/main/java/javax/persistence/UniqueConstraint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -35,7 +35,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    public class Employee { ... }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({}) 
 @Retention(RUNTIME)
@@ -44,7 +44,7 @@ public @interface UniqueConstraint {
     /** (Optional) Constraint name.  A provider-chosen name will be chosen
      * if a name is not specified.
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     String name() default "";
 

--- a/src/main/java/javax/persistence/ValidationMode.java
+++ b/src/main/java/javax/persistence/ValidationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -20,7 +20,7 @@ package javax.persistence;
  * The validation mode to be used by the provider for the persistence
  * unit.
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum ValidationMode {
    

--- a/src/main/java/javax/persistence/Version.java
+++ b/src/main/java/javax/persistence/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence;
 
@@ -50,7 +50,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    protected int getVersionNum() { return versionNum; }
  * </pre>
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)

--- a/src/main/java/javax/persistence/criteria/AbstractQuery.java
+++ b/src/main/java/javax/persistence/criteria/AbstractQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -32,7 +32,7 @@ import javax.persistence.metamodel.EntityType;
  *
  * @param <T>  the type of the result
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface AbstractQuery<T> extends CommonAbstractCriteria {
 

--- a/src/main/java/javax/persistence/criteria/CollectionJoin.java
+++ b/src/main/java/javax/persistence/criteria/CollectionJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.criteria;
@@ -28,7 +28,7 @@ import javax.persistence.metamodel.CollectionAttribute;
  * @param <Z> the source type of the join
  * @param <E> the element type of the target <code>Collection</code> 
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface CollectionJoin<Z, E> 
 		extends PluralJoin<Z, Collection<E>, E> {
@@ -39,7 +39,7 @@ public interface CollectionJoin<Z, E>
      *  Replaces the previous ON condition, if any.
      *  @param restriction  a simple or compound boolean expression
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     CollectionJoin<Z, E> on(Expression<Boolean> restriction);
 
@@ -49,7 +49,7 @@ public interface CollectionJoin<Z, E>
      *  Replaces the previous ON condition, if any.
      *  @param restrictions  zero or more restriction predicates
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     CollectionJoin<Z, E> on(Predicate... restrictions);
 

--- a/src/main/java/javax/persistence/criteria/CommonAbstractCriteria.java
+++ b/src/main/java/javax/persistence/criteria/CommonAbstractCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -28,7 +28,7 @@ package javax.persistence.criteria;
  * Update and delete operations are typed according to the target of the
  * update or delete.
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface CommonAbstractCriteria {
 

--- a/src/main/java/javax/persistence/criteria/CompoundSelection.java
+++ b/src/main/java/javax/persistence/criteria/CompoundSelection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -22,6 +22,6 @@ package javax.persistence.criteria;
  *
  * @param <X> the type of the selection item
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface CompoundSelection<X> extends Selection<X> {}

--- a/src/main/java/javax/persistence/criteria/CriteriaBuilder.java
+++ b/src/main/java/javax/persistence/criteria/CriteriaBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.criteria;
@@ -32,7 +32,7 @@ import javax.persistence.Tuple;
  * in this API in order to work around the fact that Java 
  * generics are not compatible with varags.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface CriteriaBuilder {
 
@@ -63,7 +63,7 @@ public interface CriteriaBuilder {
      *  Create a <code>CriteriaUpdate</code> query object to perform a bulk update operation.
      *  @param targetEntity  target type for update operation
      *  @return the query object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <T> CriteriaUpdate<T> createCriteriaUpdate(Class<T> targetEntity);
 
@@ -71,7 +71,7 @@ public interface CriteriaBuilder {
      *  Create a <code>CriteriaDelete</code> query object to perform a bulk delete operation.
      *  @param targetEntity  target type for delete operation
      *  @return the query object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <T> CriteriaDelete<T> createCriteriaDelete(Class<T> targetEntity);
 
@@ -1468,7 +1468,7 @@ Expression<?>... args);
      *  @param join  Join object
      *  @param type type to be downcast to
      *  @return  Join object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T, V extends T> Join<X, V> treat(Join<X, T> join, Class<V> type);
 
@@ -1477,7 +1477,7 @@ Expression<?>... args);
      *  @param join  CollectionJoin object
      *  @param type type to be downcast to
      *  @return  CollectionJoin object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T, E extends T> CollectionJoin<X, E> treat(CollectionJoin<X, T> join, Class<E> type);
 
@@ -1486,7 +1486,7 @@ Expression<?>... args);
      *  @param join  SetJoin object
      *  @param type type to be downcast to
      *  @return  SetJoin object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T, E extends T> SetJoin<X, E> treat(SetJoin<X, T> join, Class<E> type);
 
@@ -1495,7 +1495,7 @@ Expression<?>... args);
      *  @param join  ListJoin object
      *  @param type type to be downcast to
      *  @return  ListJoin object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T, E extends T> ListJoin<X, E> treat(ListJoin<X, T> join, Class<E> type);
 
@@ -1504,7 +1504,7 @@ Expression<?>... args);
      *  @param join  MapJoin object
      *  @param type type to be downcast to
      *  @return  MapJoin object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, K, T, V extends T> MapJoin<X, K, V> treat(MapJoin<X, K, T> join, Class<V> type);
 
@@ -1514,7 +1514,7 @@ Expression<?>... args);
      *  @param path  path
      *  @param type type to be downcast to
      *  @return  Path object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T extends X> Path<T> treat(Path<X> path, Class<T> type);
 
@@ -1523,7 +1523,7 @@ Expression<?>... args);
      *  @param root  root
      *  @param type type to be downcast to
      *  @return  Root object of the specified type
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     <X, T extends X> Root<T> treat(Root<X> root, Class<T> type);
 

--- a/src/main/java/javax/persistence/criteria/CriteriaDelete.java
+++ b/src/main/java/javax/persistence/criteria/CriteriaDelete.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 package javax.persistence.criteria;
 
@@ -29,7 +29,7 @@ import javax.persistence.metamodel.EntityType;
  *
  * @param <T>  the entity type that is the target of the delete
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface CriteriaDelete<T> extends CommonAbstractCriteria {
 

--- a/src/main/java/javax/persistence/criteria/CriteriaQuery.java
+++ b/src/main/java/javax/persistence/criteria/CriteriaQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -25,7 +25,7 @@ import java.util.Set;
  *
  * @param <T>  the type of the defined result
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface CriteriaQuery<T> extends AbstractQuery<T> {
 	

--- a/src/main/java/javax/persistence/criteria/CriteriaUpdate.java
+++ b/src/main/java/javax/persistence/criteria/CriteriaUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,7 +11,7 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
+//     Linda DeMichiel - 2.1
 
 
 package javax.persistence.criteria;
@@ -35,7 +35,7 @@ import javax.persistence.metamodel.EntityType;
  *
  * @param <T>  the entity type that is the target of the update
  *
- * @since Java Persistence 2.1
+ * @since 2.1
  */
 public interface CriteriaUpdate<T> extends CommonAbstractCriteria {
 

--- a/src/main/java/javax/persistence/criteria/Expression.java
+++ b/src/main/java/javax/persistence/criteria/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -23,7 +23,7 @@ import java.util.Collection;
  *
  * @param <T> the type of the expression
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Expression<T> extends Selection<T> {
 

--- a/src/main/java/javax/persistence/criteria/Fetch.java
+++ b/src/main/java/javax/persistence/criteria/Fetch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -24,7 +24,7 @@ import javax.persistence.metamodel.Attribute;
  * @param <Z>  the source type of the fetch
  * @param <X>  the target type of the fetch
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Fetch<Z, X> extends FetchParent<Z, X> {
 

--- a/src/main/java/javax/persistence/criteria/FetchParent.java
+++ b/src/main/java/javax/persistence/criteria/FetchParent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -26,7 +26,7 @@ import javax.persistence.metamodel.SingularAttribute;
  * @param <Z>  the source type
  * @param <X>  the target type
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface FetchParent<Z, X> {
 

--- a/src/main/java/javax/persistence/criteria/From.java
+++ b/src/main/java/javax/persistence/criteria/From.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.criteria;
@@ -35,7 +35,7 @@ import java.util.Set;
  * @param <Z>  the source type
  * @param <X>  the target type
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @SuppressWarnings("hiding")
 public interface From<Z, X> extends Path<X>, FetchParent<Z, X> {

--- a/src/main/java/javax/persistence/criteria/Join.java
+++ b/src/main/java/javax/persistence/criteria/Join.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -24,7 +24,7 @@ import javax.persistence.metamodel.Attribute;
  * @param <Z> the source type of the join
  * @param <X> the target type of the join
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Join<Z, X> extends From<Z, X> {
 
@@ -34,7 +34,7 @@ public interface Join<Z, X> extends From<Z, X> {
      *  Replaces the previous ON condition, if any.
      *  @param restriction  a simple or compound boolean expression
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     Join<Z, X> on(Expression<Boolean> restriction);
 
@@ -44,7 +44,7 @@ public interface Join<Z, X> extends From<Z, X> {
      *  Replaces the previous ON condition, if any.
      *  @param restrictions  zero or more restriction predicates
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     Join<Z, X> on(Predicate... restrictions);
 
@@ -53,7 +53,7 @@ public interface Join<Z, X> extends From<Z, X> {
      *  restriction(s) on the join, or null if no ON condition 
      *  has been specified.
      *  @return the ON restriction predicate
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     Predicate getOn();
 

--- a/src/main/java/javax/persistence/criteria/JoinType.java
+++ b/src/main/java/javax/persistence/criteria/JoinType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -23,7 +23,7 @@ package javax.persistence.criteria;
  * to be supported. Applications that use <code>RIGHT</code> join
  * types will not be portable.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public enum JoinType {
 

--- a/src/main/java/javax/persistence/criteria/ListJoin.java
+++ b/src/main/java/javax/persistence/criteria/ListJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.criteria;
@@ -28,7 +28,7 @@ import javax.persistence.metamodel.ListAttribute;
  * @param <Z> the source type of the join
  * @param <E> the element type of the target List
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface ListJoin<Z, E> 
 		extends PluralJoin<Z, List<E>, E> {
@@ -39,7 +39,7 @@ public interface ListJoin<Z, E>
      *  Replaces the previous ON condition, if any.
      *  @param restriction  a simple or compound boolean expression
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ListJoin<Z, E> on(Expression<Boolean> restriction);
 
@@ -49,7 +49,7 @@ public interface ListJoin<Z, E>
      *  Replaces the previous ON condition, if any.
      *  @param restrictions  zero or more restriction predicates
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     ListJoin<Z, E> on(Predicate... restrictions);
 

--- a/src/main/java/javax/persistence/criteria/MapJoin.java
+++ b/src/main/java/javax/persistence/criteria/MapJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -28,7 +28,7 @@ import javax.persistence.metamodel.MapAttribute;
  * @param <K> the type of the target Map key
  * @param <V> the type of the target Map value
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface MapJoin<Z, K, V> 
 		extends PluralJoin<Z, Map<K, V>, V> {
@@ -39,7 +39,7 @@ public interface MapJoin<Z, K, V>
      *  Replaces the previous ON condition, if any.
      *  @param restriction  a simple or compound boolean expression
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     MapJoin<Z, K, V> on(Expression<Boolean> restriction);
 
@@ -49,7 +49,7 @@ public interface MapJoin<Z, K, V>
      *  Replaces the previous ON condition, if any.
      *  @param restrictions  zero or more restriction predicates
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     MapJoin<Z, K, V> on(Predicate... restrictions);
 

--- a/src/main/java/javax/persistence/criteria/Order.java
+++ b/src/main/java/javax/persistence/criteria/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,15 +11,15 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
 /**
  * An object that defines an ordering over the query results.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Order {
 

--- a/src/main/java/javax/persistence/criteria/ParameterExpression.java
+++ b/src/main/java/javax/persistence/criteria/ParameterExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -23,6 +23,6 @@ import javax.persistence.Parameter;
  *
  * @param <T> the type of the parameter expression
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface ParameterExpression<T> extends Parameter<T>, Expression<T> {}

--- a/src/main/java/javax/persistence/criteria/Path.java
+++ b/src/main/java/javax/persistence/criteria/Path.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -27,7 +27,7 @@ import javax.persistence.metamodel.MapAttribute;
  *
  * @param <X>  the type referenced by the path
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Path<X> extends Expression<X> {
 

--- a/src/main/java/javax/persistence/criteria/PluralJoin.java
+++ b/src/main/java/javax/persistence/criteria/PluralJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -27,7 +27,7 @@ import javax.persistence.metamodel.PluralAttribute;
  * @param <C> the collection type
  * @param <E> the element type of the collection 
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface PluralJoin<Z, C, E> extends Join<Z, E> {
 

--- a/src/main/java/javax/persistence/criteria/Predicate.java
+++ b/src/main/java/javax/persistence/criteria/Predicate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -24,7 +24,7 @@ import java.util.List;
  * A simple predicate is considered to be a conjunction with a
  * single conjunct.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Predicate extends Expression<Boolean> {
 

--- a/src/main/java/javax/persistence/criteria/Root.java
+++ b/src/main/java/javax/persistence/criteria/Root.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -24,7 +24,7 @@ import javax.persistence.metamodel.EntityType;
  *
  * @param <X> the entity type referenced by the root
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Root<X> extends From<X, X> {
 

--- a/src/main/java/javax/persistence/criteria/Selection.java
+++ b/src/main/java/javax/persistence/criteria/Selection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -25,7 +25,7 @@ import java.util.List;
  *
  * @param <X> the type of the selection item
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Selection<X> extends TupleElement<X> {
 

--- a/src/main/java/javax/persistence/criteria/SetJoin.java
+++ b/src/main/java/javax/persistence/criteria/SetJoin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.criteria;
 
@@ -27,7 +27,7 @@ import javax.persistence.metamodel.SetAttribute;
  * @param <Z> the source type of the join
  * @param <E> the element type of the target <code>Set</code> 
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
 
@@ -37,7 +37,7 @@ public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
      *  Replaces the previous ON condition, if any.
      *  @param restriction  a simple or compound boolean expression
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     SetJoin<Z, E> on(Expression<Boolean> restriction);
 
@@ -47,7 +47,7 @@ public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
      *  Replaces the previous ON condition, if any.
      *  @param restrictions  zero or more restriction predicates
      *  @return the modified join object
-     *  @since Java Persistence 2.1
+     *  @since 2.1
      */
     SetJoin<Z, E> on(Predicate... restrictions);
 

--- a/src/main/java/javax/persistence/criteria/Subquery.java
+++ b/src/main/java/javax/persistence/criteria/Subquery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.criteria;
@@ -28,7 +28,7 @@ import java.util.Set;
  *
  * @param <T> the type of the selection item.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Subquery<T> extends AbstractQuery<T>, Expression<T> {
 	
@@ -191,7 +191,7 @@ public interface Subquery<T> extends AbstractQuery<T>, Expression<T> {
      * This may be a CriteriaQuery, CriteriaUpdate, CriteriaDelete,
      * or a Subquery.
      * @return the enclosing query or subquery
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     CommonAbstractCriteria getContainingQuery();
 	

--- a/src/main/java/javax/persistence/criteria/package-info.java
+++ b/src/main/java/javax/persistence/criteria/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,10 +11,10 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 /**
- * Java Persistence Criteria API
+ * Jakarta Persistence Criteria API
  */
 package javax.persistence.criteria;

--- a/src/main/java/javax/persistence/metamodel/Attribute.java
+++ b/src/main/java/javax/persistence/metamodel/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -22,7 +22,7 @@ package javax.persistence.metamodel;
  * @param <X> The represented type that contains the attribute
  * @param <Y> The type of the represented attribute
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Attribute<X, Y> {
 

--- a/src/main/java/javax/persistence/metamodel/BasicType.java
+++ b/src/main/java/javax/persistence/metamodel/BasicType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -22,6 +22,6 @@ package javax.persistence.metamodel;
  *
  * @param <X> The type of the represented basic type
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface BasicType<X> extends Type<X> {}

--- a/src/main/java/javax/persistence/metamodel/Bindable.java
+++ b/src/main/java/javax/persistence/metamodel/Bindable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -22,7 +22,7 @@ package javax.persistence.metamodel;
  *
  * @param <T>  The type of the represented object or attribute
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public interface Bindable<T> {

--- a/src/main/java/javax/persistence/metamodel/CollectionAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/CollectionAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -23,7 +23,7 @@ package javax.persistence.metamodel;
  * @param <X> The type the represented Collection belongs to
  * @param <E> The element type of the represented Collection
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public interface CollectionAttribute<X, E> 

--- a/src/main/java/javax/persistence/metamodel/EmbeddableType.java
+++ b/src/main/java/javax/persistence/metamodel/EmbeddableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -21,7 +21,7 @@ package javax.persistence.metamodel;
  *
  *  @param <X> The represented type.
  *
- *  @since Java Persistence 2.0
+ *  @since 2.0
  *
  */
 public interface EmbeddableType<X> extends ManagedType<X> {}

--- a/src/main/java/javax/persistence/metamodel/EntityType.java
+++ b/src/main/java/javax/persistence/metamodel/EntityType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -21,7 +21,7 @@ package javax.persistence.metamodel;
  *
  *  @param <X> The represented entity type.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public interface EntityType<X> 

--- a/src/main/java/javax/persistence/metamodel/IdentifiableType.java
+++ b/src/main/java/javax/persistence/metamodel/IdentifiableType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -24,7 +24,7 @@ import java.util.Set;
  *
  *  @param <X> The represented entity or mapped superclass type.
  *
- *  @since Java Persistence 2.0
+ *  @since 2.0
  *
  */
 public interface IdentifiableType<X> extends ManagedType<X> {

--- a/src/main/java/javax/persistence/metamodel/ListAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/ListAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -23,7 +23,7 @@ package javax.persistence.metamodel;
  * @param <X> The type the represented List belongs to
  * @param <E> The element type of the represented List
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public interface ListAttribute<X, E> 

--- a/src/main/java/javax/persistence/metamodel/ManagedType.java
+++ b/src/main/java/javax/persistence/metamodel/ManagedType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -24,7 +24,7 @@ import java.util.Set;
  *
  *  @param <X> The represented type.
  *
- *  @since Java Persistence 2.0
+ *  @since 2.0
  *
  */
 public interface ManagedType<X> extends Type<X> {

--- a/src/main/java/javax/persistence/metamodel/MapAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/MapAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -24,7 +24,7 @@ package javax.persistence.metamodel;
  * @param <K> The type of the key of the represented Map
  * @param <V> The type of the value of the represented Map
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public interface MapAttribute<X, K, V> 

--- a/src/main/java/javax/persistence/metamodel/MappedSuperclassType.java
+++ b/src/main/java/javax/persistence/metamodel/MappedSuperclassType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.metamodel;
@@ -22,6 +22,6 @@ package javax.persistence.metamodel;
  *  superclass types.
  *
  *  @param <X> The represented entity type
- *  @since Java Persistence 2.0
+ *  @since 2.0
  */
 public interface MappedSuperclassType<X> extends IdentifiableType<X> {}

--- a/src/main/java/javax/persistence/metamodel/Metamodel.java
+++ b/src/main/java/javax/persistence/metamodel/Metamodel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -22,7 +22,7 @@ import java.util.Set;
  * Provides access to the metamodel of persistent
  * entities in the persistence unit. 
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Metamodel {
 

--- a/src/main/java/javax/persistence/metamodel/PluralAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/PluralAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -24,7 +24,7 @@ package javax.persistence.metamodel;
  * @param <C> The type of the represented collection
  * @param <E> The element type of the represented collection
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface PluralAttribute<X, C, E> 
 		extends Attribute<X, C>, Bindable<E> {

--- a/src/main/java/javax/persistence/metamodel/SetAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/SetAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -23,7 +23,7 @@ package javax.persistence.metamodel;
  * @param <X> The type the represented Set belongs to
  * @param <E> The element type of the represented Set
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface SetAttribute<X, E> 
 	extends PluralAttribute<X, java.util.Set<E>, E> {} 

--- a/src/main/java/javax/persistence/metamodel/SingularAttribute.java
+++ b/src/main/java/javax/persistence/metamodel/SingularAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.metamodel;
@@ -24,7 +24,7 @@ package javax.persistence.metamodel;
  * @param <X> The type containing the represented attribute
  * @param <T> The type of the represented attribute
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface SingularAttribute<X, T> 
 		extends Attribute<X, T>, Bindable<T> {

--- a/src/main/java/javax/persistence/metamodel/StaticMetamodel.java
+++ b/src/main/java/javax/persistence/metamodel/StaticMetamodel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 
 package javax.persistence.metamodel;
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * superclass, or embeddable class designated by the value
  * element.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/javax/persistence/metamodel/Type.java
+++ b/src/main/java/javax/persistence/metamodel/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.metamodel;
 
@@ -22,7 +22,7 @@ package javax.persistence.metamodel;
  *
  * @param <X>  The type of the represented object or attribute
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface Type<X> {
 

--- a/src/main/java/javax/persistence/metamodel/package-info.java
+++ b/src/main/java/javax/persistence/metamodel/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,10 +11,10 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 /**
- * Java Persistence Metamodel API
+ * Jakarta Persistence Metamodel API
  */
 package javax.persistence.metamodel;

--- a/src/main/java/javax/persistence/package-info.java
+++ b/src/main/java/javax/persistence/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,15 +11,10 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
-
-
-
-/////
-// Java Persistence is the API for the management for persistence and object/relational mapping.
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 /**
- * Java Persistence is the API for the management for persistence and object/relational mapping.
+ * Jakarta Persistence is the API for the management for persistence and object/relational mapping.
  */
 package javax.persistence;

--- a/src/main/java/javax/persistence/spi/ClassTransformer.java
+++ b/src/main/java/javax/persistence/spi/ClassTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -28,7 +28,7 @@ import java.lang.instrument.IllegalClassFormatException;
  * loaded or redefined. The transformation occurs before  
  * the class is defined by the JVM.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface ClassTransformer {
 

--- a/src/main/java/javax/persistence/spi/LoadState.java
+++ b/src/main/java/javax/persistence/spi/LoadState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,14 +11,14 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
 /**
  * Load states returned by the {@link ProviderUtil} SPI methods.
- * @since Java Persistence 2.0
+ * @since 2.0
  *
  */
 public enum LoadState {

--- a/src/main/java/javax/persistence/spi/PersistenceProvider.java
+++ b/src/main/java/javax/persistence/spi/PersistenceProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -23,12 +23,12 @@ import java.util.Map;
 /**
  * Interface implemented by the persistence provider.
  *
- * <p> It is invoked by the container in Java EE environments and
+ * <p> It is invoked by the container in Jakarta EE environments and
  * by the {@link javax.persistence.Persistence} class in Java SE environments to
  * create an {@link javax.persistence.EntityManagerFactory} and/or to cause
  * schema generation to occur.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface PersistenceProvider {
 
@@ -84,7 +84,7 @@ public interface PersistenceProvider {
      *         configuration information is provided of if schema
      *         generation otherwise fails
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public void generateSchema(PersistenceUnitInfo info, Map map);
 
@@ -106,7 +106,7 @@ public interface PersistenceProvider {
      *         configuration information is provided or if schema
      *         generation otherwise fails
      *
-     * @since Java Persistence 2.1
+     * @since 2.1
      */
     public boolean generateSchema(String persistenceUnitName, Map map); 
 
@@ -115,7 +115,7 @@ public interface PersistenceProvider {
      * provider.
      * @return ProviderUtil interface
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public ProviderUtil getProviderUtil();
 }

--- a/src/main/java/javax/persistence/spi/PersistenceProviderResolver.java
+++ b/src/main/java/javax/persistence/spi/PersistenceProviderResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -29,7 +29,7 @@ import java.util.List;
  * of this method make use of caching.
  *
  * @see PersistenceProvider
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface PersistenceProviderResolver {
 

--- a/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
+++ b/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,9 +11,9 @@
  */
 
 // Contributors:
-//     Lukas Jungmann  - Java Persistence 2.2
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Lukas Jungmann  - 2.2
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
  * 
  * Implementations must be thread-safe.
  * 
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public class PersistenceProviderResolverHolder {
 
@@ -70,7 +70,7 @@ public class PersistenceProviderResolverHolder {
     /**
      * Default provider resolver class to use when none is explicitly set.
      * 
-     * Uses service loading mechanism as described in the Java Persistence
+     * Uses service loading mechanism as described in the Jakarta Persistence
      * specification. A ServiceLoader.load() call is made with the current context
      * classloader to find the service provider files on the classpath.
      */

--- a/src/main/java/javax/persistence/spi/PersistenceUnitInfo.java
+++ b/src/main/java/javax/persistence/spi/PersistenceUnitInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -27,7 +27,7 @@ import javax.persistence.ValidationMode;
  * Interface implemented by the container and used by the
  * persistence provider when creating an {@link javax.persistence.EntityManagerFactory}.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public interface PersistenceUnitInfo {
 	
@@ -149,7 +149,7 @@ public interface PersistenceUnitInfo {
      * @return the second-level cache mode that must be used by the
      * provider for the persistence unit
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public SharedCacheMode getSharedCacheMode();
 
@@ -161,7 +161,7 @@ public interface PersistenceUnitInfo {
      * @return the validation mode to be used by the 
      * persistence provider for the persistence unit
      * 
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public ValidationMode getValidationMode();
 
@@ -177,7 +177,7 @@ public interface PersistenceUnitInfo {
      * Returns the schema version of the <code>persistence.xml</code> file.
      * @return persistence.xml schema version
      *
-     * @since Java Persistence 2.0
+     * @since 2.0
      */
     public String getPersistenceXMLSchemaVersion();
 

--- a/src/main/java/javax/persistence/spi/PersistenceUnitTransactionType.java
+++ b/src/main/java/javax/persistence/spi/PersistenceUnitTransactionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -21,7 +21,7 @@ package javax.persistence.spi;
  * javax.persistence.EntityManagerFactory} will be JTA or
  * resource-local entity managers.
  *
- * @since Java Persistence 1.0
+ * @since 1.0
  */
 public enum PersistenceUnitTransactionType {
 

--- a/src/main/java/javax/persistence/spi/ProviderUtil.java
+++ b/src/main/java/javax/persistence/spi/ProviderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,8 +11,8 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 package javax.persistence.spi;
 
@@ -22,7 +22,7 @@ package javax.persistence.spi;
  * javax.persistence.PersistenceUtil} implementation to determine
  * the load status of an entity or entity attribute.
  *
- * @since Java Persistence 2.0
+ * @since 2.0
  */
 public interface ProviderUtil { 
 

--- a/src/main/java/javax/persistence/spi/package-info.java
+++ b/src/main/java/javax/persistence/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -11,10 +11,10 @@
  */
 
 // Contributors:
-//     Linda DeMichiel - Java Persistence 2.1
-//     Linda DeMichiel - Java Persistence 2.0
+//     Linda DeMichiel - 2.1
+//     Linda DeMichiel - 2.0
 
 /**
- * SPI for Java Persistence providers
+ * SPI for Jakarta Persistence providers
  */
 package javax.persistence.spi;

--- a/src/main/javadoc/doc-files/EFSL.html
+++ b/src/main/javadoc/doc-files/EFSL.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+<title>Eclipse Foundation Specification License - v1.0</title>
+</head>
+<body>
+<h1>Eclipse Foundation Specification License - v1.0</h1>
+<p>By using and/or copying this document, or the Eclipse Foundation
+  document from which this statement is linked, you (the licensee) agree
+  that you have read, understood, and will comply with the following
+  terms and conditions:</p>
+
+<p>Permission to copy, and distribute the contents of this document, or
+  the Eclipse Foundation document from which this statement is linked, in
+  any medium for any purpose and without fee or royalty is hereby
+  granted, provided that you include the following on ALL copies of the
+  document, or portions thereof, that you use:</p>
+
+<ul>
+  <li> link or URL to the original Eclipse Foundation document.</li>
+  <li>All existing copyright notices, or if one does not exist, a notice
+      (hypertext is preferred, but a textual representation is permitted)
+      of the form: &quot;Copyright &copy; [$date-of-document]
+      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      &quot;
+  </li>
+</ul>
+
+<p>Inclusion of the full text of this NOTICE must be provided. We
+  request that authorship attribution be provided in any software,
+  documents, or other items or products that you create pursuant to the
+  implementation of the contents of this document, or any portion
+  thereof.</p>
+
+<p>No right to create modifications or derivatives of Eclipse Foundation
+  documents is granted pursuant to this license, except anyone may
+  prepare and distribute derivative works and portions of this document
+  in software that implements the specification, in supporting materials
+  accompanying such software, and in documentation of such software,
+  PROVIDED that all such works include the notice below. HOWEVER, the
+  publication of derivative works of this document for use as a technical
+  specification is expressly prohibited.</p>
+
+<p>The notice is:</p>
+
+<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+  document includes material copied from or derived from [title and URI
+  of the Eclipse Foundation specification document].&quot;</p>
+
+<h2>Disclaimers</h2>
+
+<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
+  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
+  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
+  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
+  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+  OTHER RIGHTS.</p>
+
+<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
+  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
+  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
+  CONTENTS THEREOF.</p>
+
+<p>The name and trademarks of the copyright holders or the Eclipse
+  Foundation may NOT be used in advertising or publicity pertaining to
+  this document or its contents without specific, written prior
+  permission. Title to copyright in this document will at all times
+  remain with copyright holders.</p>
+
+</body>
+</html>

--- a/src/main/resources/javax/persistence/orm_1_0.xsd
+++ b/src/main/resources/javax/persistence/orm_1_0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,22 +12,7 @@
 
 -->
 
-<!--
-        Contributors: dclarke - Java Persistence 2.0 - Proposed Final Draft (March 13,
-        2009) Specification available from http://jcp.org/en/jsr/detail?id=317
--->
-<!--
-        Java(TM) Persistence API, Version 2.0 - EARLY ACCESS This is an implementation
-        of an early-draft specification developed under the Java Community Process
-        (JCP). The code is untested and presumed not to be a compatible implementation
-        of JSR 317: Java(TM) Persistence API, Version 2.0. We encourage you to migrate
-        to an implementation of the Java(TM) Persistence API, Version 2.0
-        Specification that has been tested and verified to be compatible as soon as
-        such an implementation is available, and we encourage you to retain this
-        notice in any implementation of Java(TM) Persistence API, Version 2.0
-        Specification that you distribute.
--->
-<!-- Java Persistence API object-relational mapping file schema -->
+<!-- Jakarta Persistence API object-relational mapping file schema -->
 <xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence/orm" 
   xmlns:orm="http://java.sun.com/xml/ns/persistence/orm" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 

--- a/src/main/resources/javax/persistence/orm_2_0.xsd
+++ b/src/main/resources/javax/persistence/orm_2_0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,7 +12,7 @@
 
 -->
 
-<!-- Java Persistence API object/relational mapping file schema -->
+<!-- Jakarta Persistence API object/relational mapping file schema -->
 <xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence/orm" 
   xmlns:orm="http://java.sun.com/xml/ns/persistence/orm" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
@@ -29,7 +29,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,9 +40,8 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
   Contributors:
-      Linda DeMichiel - Java Persistence 2.0, Version 2.0 (October 1, 2009)
-      Specification available from http://jcp.org/en/jsr/detail?id=317
-  
+      Linda DeMichiel - Version 2.0 (October 1, 2009)
+
     </xsd:documentation>
   </xsd:annotation>
 

--- a/src/main/resources/javax/persistence/orm_2_1.xsd
+++ b/src/main/resources/javax/persistence/orm_2_1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,7 +12,7 @@
 
 -->
 
-<!-- Java Persistence API object/relational mapping file schema -->
+<!-- Jakarta Persistence API object/relational mapping file schema -->
 <xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/persistence/orm" 
   xmlns:orm="http://xmlns.jcp.org/xml/ns/persistence/orm" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
@@ -29,7 +29,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,9 +40,8 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
   Contributors:
-      Linda DeMichiel - Java Persistence 2.1, Version 2.1 (February 15, 2013)
-      Specification available from http://jcp.org/en/jsr/detail?id=338
-  
+      Linda DeMichiel - Version 2.1 (February 15, 2013)
+
     </xsd:documentation>
   </xsd:annotation>
 

--- a/src/main/resources/javax/persistence/orm_2_2.xsd
+++ b/src/main/resources/javax/persistence/orm_2_2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,7 +12,7 @@
 
 -->
 
-<!-- Java Persistence API object/relational mapping file schema -->
+<!-- Jakarta Persistence API object/relational mapping file schema -->
 <xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/persistence/orm" 
   xmlns:orm="http://xmlns.jcp.org/xml/ns/persistence/orm" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
@@ -29,7 +29,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,9 +40,8 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
   Contributors:
-      Linda DeMichiel - Java Persistence 2.2, Version 2.2 (July 7, 2017)
-      Specification available from http://jcp.org/en/jsr/detail?id=338
-  
+      Linda DeMichiel - Version 2.2 (July 7, 2017)
+
     </xsd:documentation>
   </xsd:annotation>
 

--- a/src/main/resources/javax/persistence/persistence_1_0.xsd
+++ b/src/main/resources/javax/persistence/persistence_1_0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2006, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2006, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,21 +12,6 @@
 
 -->
 
-<!--
-        Contributors: dclarke - Java Persistence 2.0 - Proposed Final Draft (March 13,
-        2009) Specification available from http://jcp.org/en/jsr/detail?id=317
--->
-<!--
-        Java(TM) Persistence API, Version 2.0 - EARLY ACCESS This is an implementation
-        of an early-draft specification developed under the Java Community Process
-        (JCP). The code is untested and presumed not to be a compatible implementation
-        of JSR 317: Java(TM) Persistence API, Version 2.0. We encourage you to migrate
-        to an implementation of the Java(TM) Persistence API, Version 2.0
-        Specification that has been tested and verified to be compatible as soon as
-        such an implementation is available, and we encourage you to retain this
-        notice in any implementation of Java(TM) Persistence API, Version 2.0
-        Specification that you distribute.
--->
 <!-- persistence.xml schema -->
 <xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"

--- a/src/main/resources/javax/persistence/persistence_2_0.xsd
+++ b/src/main/resources/javax/persistence/persistence_2_0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,19 +29,19 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2009 Sun Microsystems. All rights reserved. 
-  
-  This program and the accompanying materials are made available under the 
-  terms of the Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0 
-  which accompanies this distribution. 
-  The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
-  and the Eclipse Distribution License is available at 
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
+
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License v. 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0,
+  or the Eclipse Distribution License v. 1.0 which is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
-  
+
+  SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
   Contributors:
-      Linda DeMichiel - Java Persistence 2.0, Version 2.0 (October 1, 2009)
-      Specification available from http://jcp.org/en/jsr/detail?id=317
- 
+      Linda DeMichiel - Version 2.0 (October 1, 2009)
+
     </xsd:documentation>
   </xsd:annotation>
 

--- a/src/main/resources/javax/persistence/persistence_2_1.xsd
+++ b/src/main/resources/javax/persistence/persistence_2_1.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,7 +29,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,9 +40,8 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
   Contributors:
-      Linda DeMichiel - Java Persistence 2.1, Version 2.1 (February 4, 2013)
-      Specification available from http://jcp.org/en/jsr/detail?id=338
- 
+      Linda DeMichiel - Version 2.1 (February 4, 2013)
+
     </xsd:documentation>
   </xsd:annotation>
 

--- a/src/main/resources/javax/persistence/persistence_2_2.xsd
+++ b/src/main/resources/javax/persistence/persistence_2_2.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
-    Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,7 +29,7 @@
   <xsd:annotation>
     <xsd:documentation>
 
-  Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+  Copyright (c) 2008, 2019 Oracle and/or its affiliates. All rights reserved.
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,9 +40,8 @@
   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 
   Contributors:
-      Linda DeMichiel - Java Persistence 2.2, Version 2.2 (July 7, 2017)
-      Specification available from http://jcp.org/en/jsr/detail?id=338
- 
+      Linda DeMichiel - Version 2.2 (July 7, 2017)
+
     </xsd:documentation>
   </xsd:annotation>
 


### PR DESCRIPTION
* removed "Java Persistence" from the since javadoc tag
* replaced "Java EE" with "Jakarta EE"
* replaced "Java Persistence" with "Jakarta Persistence" where appropriate
* kept "JTA" untouched and without explicit mention of Jakarta Transaction API - reason is that, in my opinion, all references are tight to either schema defined elements (jta-data-source/non-jta-data-source) or defined transaction types (JTA/RESOURCE_LOCAL) which we cannot change
