### PR TITLE
change module name to jakarta.persistence

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -229,7 +229,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
-                        <Automatic-Module-Name>java.persistence</Automatic-Module-Name>
+                        <Automatic-Module-Name>jakarta.persistence</Automatic-Module-Name>
                         <Bundle-Description>Jakarta Persistence ${spec.specification.version} API jar</Bundle-Description>
                         <Bundle-Name>Jakarta Persistence API jar</Bundle-Name>
                         <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

> cat api/target/classes/META-INF/MANIFEST.MF
> Manifest-Version: 1.0
> Automatic-Module-Name: jakarta.persistence
> Bnd-LastModified: 1580494494199
> Build-Jdk: 1.8.0_181
> Built-By: smarlow
> Bundle-Description: Jakarta Persistence 2.2 API jar
> Bundle-DocURL: https://www.eclipse.org
> Bundle-License: http://www.eclipse.org/legal/epl-2.0, http://www.eclipse
>  .org/org/documents/edl-v10.php
> Bundle-ManifestVersion: 2
> Bundle-Name: Jakarta Persistence API jar
> Bundle-SymbolicName: jakarta.persistence-api
> Bundle-Vendor: Eclipse Foundation
> Bundle-Version: 2.2.3
> Created-By: Apache Maven Bundle Plugin
> Export-Package: jakarta.persistence;uses:="jakarta.persistence.criteria,
>  jakarta.persistence.metamodel,jakarta.persistence.spi";version="2.2.3",
>  jakarta.persistence.spi;uses:="jakarta.persistence,javax.sql";version="
>  2.2.3",jakarta.persistence.metamodel;version="2.2.3",jakarta.persistenc
>  e.criteria;uses:="jakarta.persistence,jakarta.persistence.metamodel";ve
>  rsion="2.2.3"
> Extension-Name: jakarta.persistence
> Implementation-Version: 2.2.3
> Import-Package: jakarta.persistence,jakarta.persistence.criteria,jakarta
>  .persistence.metamodel,jakarta.persistence.spi,javax.sql
> Specification-Vendor: Eclipse Foundation
> Specification-Version: 2.2
> Tool: Bnd-3.5.0.201709291849
> 