### PR TITLE
Updated references to point to Jakarta project pages

### DIFF
--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -5,22 +5,11 @@
 [bibliography]
 == Related Documents
 
-- [[[a19493,1]]]JSR-220:
-Enterprise JavaBeans, v. 3.0. Java Persistence API.
-_http://jcp.org/en/jsr/detail?id=220_.
-- [[[a19494,2]]]SQL 2003, Part 2,
-Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
-- [[[a19496,3]]]JDBC 4.2
-Specification. http://jcp.org/en/jsr/detail?id=221.
-- [[[a19497,4]]]Enterprise JavaBeans, v.
-2.1. _http://jcp.org/en/jsr/detail?id=153_.
-- [[[a19498,5]]]JSR-380: Bean Validation,
-v. 2.0. _http://jcp.org/en/jsr/detail?id=380_.
-- [[[a19499,6]]]JSR-366: Java Platform,
-Enterprise Edition 8 (Java EE 8) Specification.
-_http://jcp.org/en/jsr/detail?id=366[http://jcp.org/en/jsr/detail?id=366.]_
-- [[[a19500,7]]]JSR-365: Context and
-Dependency Injection for Java EE, v 2.0.
-_http://jcp.org/en/jsr/detail?id=365[http://jcp.org/en/jsr/detail?id=365.]_
-- [[[a19501,8]]]JSR-317: Java Persistence
-2.0. _http://jcp.org/en/jsr/detail?id=317_.
+- [[[a19493,1]]]Enterprise JavaBeans, v. 3.0. Java Persistence API.
+- [[[a19494,2]]]SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
+- [[[a19496,3]]]JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
+- [[[a19497,4]]]Enterprise JavaBeans, v. 2.1.
+- [[[a19498,5]]]Jakarta Bean Validation, v. 3.0. _https://projects.eclipse.org/projects/ee4j.bean-validation_.
+- [[[a19499,6]]]Jakarta EE Platform, v. 9.0._https://projects.eclipse.org/projects/ee4j.jakartaee-platform_.
+- [[[a19500,7]]]Jakarta Contexts and Dependency Injection, v 3.0. _https://projects.eclipse.org/projects/ee4j.cdi_.
+- [[[a19501,8]]]Java(R) Persistence, v. 2.0.

--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -10,6 +10,6 @@
 - [[[a19496,3]]] JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
 - [[[a19497,4]]] Enterprise JavaBeans, v. 2.1.
 - [[[a19498,5]]] Jakarta Bean Validation, v. 3.0. _https://jakarta.ee/specifications/bean-validation/3.0/_.
-- [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9_.
-- [[[a19500,7]]] Jakarta Contexts and Dependency Injection, v 3.0. _https://projects.eclipse.org/projects/ee4j.cdi_.
+- [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://jakarta.ee/specifications/platform/9/_.
+- [[[a19500,7]]] Jakarta Contexts and Dependency Injection, v 3.0. _https://jakarta.ee/specifications/cdi/3.0/_.
 - [[[a19501,8]]] Java(R) Persistence, v. 2.0.

--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -9,7 +9,7 @@
 - [[[a19494,2]]] SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
 - [[[a19496,3]]] JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
 - [[[a19497,4]]] Enterprise JavaBeans, v. 2.1.
-- [[[a19498,5]]] Jakarta Bean Validation, v. 3.0. _https://projects.eclipse.org/projects/ee4j.bean-validation_.
-- [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://projects.eclipse.org/projects/ee4j.jakartaee-platform_.
+- [[[a19498,5]]] Jakarta Bean Validation, v. 3.0. _https://jakarta.ee/specifications/bean-validation/3.0/_.
+- [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee9/JakartaEE9_.
 - [[[a19500,7]]] Jakarta Contexts and Dependency Injection, v 3.0. _https://projects.eclipse.org/projects/ee4j.cdi_.
 - [[[a19501,8]]] Java(R) Persistence, v. 2.0.

--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -5,11 +5,11 @@
 [bibliography]
 == Related Documents
 
-- [[[a19493,1]]]Enterprise JavaBeans, v. 3.0. Java Persistence API.
-- [[[a19494,2]]]SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
-- [[[a19496,3]]]JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
-- [[[a19497,4]]]Enterprise JavaBeans, v. 2.1.
-- [[[a19498,5]]]Jakarta Bean Validation, v. 3.0. _https://projects.eclipse.org/projects/ee4j.bean-validation_.
-- [[[a19499,6]]]Jakarta EE Platform, v. 9.0._https://projects.eclipse.org/projects/ee4j.jakartaee-platform_.
-- [[[a19500,7]]]Jakarta Contexts and Dependency Injection, v 3.0. _https://projects.eclipse.org/projects/ee4j.cdi_.
-- [[[a19501,8]]]Java(R) Persistence, v. 2.0.
+- [[[a19493,1]]] Enterprise JavaBeans, v. 3.0. Java Persistence API.
+- [[[a19494,2]]] SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
+- [[[a19496,3]]] JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
+- [[[a19497,4]]] Enterprise JavaBeans, v. 2.1.
+- [[[a19498,5]]] Jakarta Bean Validation, v. 3.0. _https://projects.eclipse.org/projects/ee4j.bean-validation_.
+- [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://projects.eclipse.org/projects/ee4j.jakartaee-platform_.
+- [[[a19500,7]]] Jakarta Contexts and Dependency Injection, v 3.0. _https://projects.eclipse.org/projects/ee4j.cdi_.
+- [[[a19501,8]]] Java(R) Persistence, v. 2.0.


### PR DESCRIPTION
I updated references to point to the eclipse project instead of jcp pages. For some of them that were referencing an old version of specs, I just changed them to just the spec name and spec version (suggested in the "Cleanup Steps" of the [Converting Java EE Specification Documents to Jakarta EE.
](https://github.com/jakartaee/specification-committee/blob/master/steps_javaee_to_jakartaee.adoc)

I'm not sure about the number 3, "JDBC 4.2 Specification". It's not an eclipse-ee4j project, so I didn't change the URL.