### PR TITLE
Drop references to older/Java EE versions of the schema from the spec

### DIFF
--- a/spec/src/main/asciidoc/ch08-entity-packaging.adoc
+++ b/spec/src/main/asciidoc/ch08-entity-packaging.adoc
@@ -301,11 +301,7 @@ files will be searched for managed persistence classes, and any mapping
 metadata annotations found on them will be processed, or they will be
 mapped using the mapping annotation defaults defined by this
 specification. Such JAR files are specified relative to the directory or
-jar file that _contains_footnote:[This semantics
-applies to persistence.xml files written to the persistence_2_0.xsd or
-later schema. Due to ambiguity in the Java Persistence 1.0
-specification, provider-specific interpretation of the relative
-references used by this element may apply to earlier versions.] the root of the
+jar file that _contains_ the root of the
 persistence unit.footnote:[Persistence providers
 are encouraged to support this syntax for use in Java SE environments.]
 

--- a/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
+++ b/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
@@ -20,9 +20,7 @@ discovering the _persistence.xml_ files and processing them.
 When the container finds a _persistence.xml_
 file, it must process the persistence unit definitions that it contains.
 The container must validate the _persistence.xml_ file against the
-_persistence_2_2.xsd_, _persistence_2_1.xsd_, _persistence_2_0.xsd_,
-or _persistence_1_0.xsd_ schema in accordance with the version specified
-by the _persistence.xml_ file and report any validation errors. Provider
+_persistence_3_0.xsd_ schema and report any validation errors. Provider
 or data source information not specified in the _persistence.xml_ file
 must be provided at deployment time or defaulted by the container. The
 container may optionally add any container-specific properties to be

--- a/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
+++ b/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
@@ -20,8 +20,9 @@ discovering the _persistence.xml_ files and processing them.
 When the container finds a _persistence.xml_
 file, it must process the persistence unit definitions that it contains.
 The container must validate the _persistence.xml_ file against the
-_persistence_3_0.xsd_ schema and report any validation errors. Provider
-or data source information not specified in the _persistence.xml_ file
+__persistence_3_0.xsd__ or __persistence_2_2.xsd__ schema in accordance with
+the version specified by the _persistence.xml_ file and report any validation errors.
+Provider or data source information not specified in the _persistence.xml_ file
 must be provided at deployment time or defaulted by the container. The
 container may optionally add any container-specific properties to be
 passed to the provider when creating the entity manager factory for the

--- a/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
+++ b/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
@@ -38,7 +38,10 @@ subelement is not specified, the XML descriptor overrides the values set
 or defaulted by the use of annotations, as described below.
 
 The mapping files used by the application
-developer must conform to the XML schema defined in <<a17175>>.
+developer must conform to the XML schema defined in <<a17175>>
+or to the previous version of the XML schema, __orm_2_2.xsd__,
+defined in a previous version of this specification <<a19493>>
+in accordance with the version specified by the _orm.xml_ file.
 
 The Jakarta Persistence persistence provider
 may support use of older versions of the object/relational mapping

--- a/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
+++ b/spec/src/main/asciidoc/ch12-xml-or-mapping-descriptor.adoc
@@ -38,12 +38,10 @@ subelement is not specified, the XML descriptor overrides the values set
 or defaulted by the use of annotations, as described below.
 
 The mapping files used by the application
-developer must conform to the XML schema defined in <<a17175>> or to the object/relational
-mapping schema defined in a previous version of this specification
-<<a19493>>, <<a19501>>.
+developer must conform to the XML schema defined in <<a17175>>.
 
-The Java Persistence persistence provider
-must support use of older versions of the object/relational mapping
+The Jakarta Persistence persistence provider
+may support use of older versions of the object/relational mapping
 schema as well as the object/relational mapping schema defined in
 <<a17175>>, whether singly or
 in combination when multiple mapping files are used.

--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -5,7 +5,7 @@
 [bibliography]
 == Related Documents
 
-- [[[a19493,1]]] Jakarta Persistence, v. 2.3.
+- [[[a19493,1]]] Jakarta Persistence, v. 2.2. _https://jakarta.ee/specifications/persistence/2.2/_.
 - [[[a19494,2]]] SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
 - [[[a19496,3]]] JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
 - [[[a19497,4]]] Enterprise JavaBeans, v. 2.1.

--- a/spec/src/main/asciidoc/related-documents.adoc
+++ b/spec/src/main/asciidoc/related-documents.adoc
@@ -5,11 +5,10 @@
 [bibliography]
 == Related Documents
 
-- [[[a19493,1]]] Enterprise JavaBeans, v. 3.0. Java Persistence API.
+- [[[a19493,1]]] Jakarta Persistence, v. 2.3.
 - [[[a19494,2]]] SQL 2003, Part 2, Foundation (SQL/Foundation). ISO/IEC 9075-2:2003.
 - [[[a19496,3]]] JDBC 4.2 Specification. http://jcp.org/en/jsr/detail?id=221.
 - [[[a19497,4]]] Enterprise JavaBeans, v. 2.1.
 - [[[a19498,5]]] Jakarta Bean Validation, v. 3.0. _https://jakarta.ee/specifications/bean-validation/3.0/_.
 - [[[a19499,6]]] Jakarta EE Platform, v. 9.0. _https://jakarta.ee/specifications/platform/9/_.
 - [[[a19500,7]]] Jakarta Contexts and Dependency Injection, v 3.0. _https://jakarta.ee/specifications/cdi/3.0/_.
-- [[[a19501,8]]] Java(R) Persistence, v. 2.0.


### PR DESCRIPTION
With relaxed overall backwards compatibility related requirements of Jakarta EE 9, I'd like to remove explicit requirements wrt supporting older/Java EE schemas defined in the persistence spec