### PR TITLE
#264: avoid transitive dependency on java.instrument

### DIFF
--- a/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
+++ b/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,8 +29,10 @@ import java.lang.instrument.IllegalClassFormatException;
  * the class is defined by the JVM.
  *
  * @since 1.0
+ * @deprecated Use {@link Transformer}.
  */
-public interface ClassTransformer {
+@Deprecated
+public interface ClassTransformer extends Transformer {
 
     /**
      * Invoked when a class is being loaded or redefined.

--- a/api/src/main/java/jakarta/persistence/spi/PersistenceUnitInfo.java
+++ b/api/src/main/java/jakarta/persistence/spi/PersistenceUnitInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -203,7 +203,7 @@ public interface PersistenceUnitInfo {
      * @param transformer   provider-supplied transformer that the
      * container invokes at class-(re)definition time
      */
-    public void addTransformer(ClassTransformer transformer);
+    public void addTransformer(Transformer transformer);
 
     /**
      * Return a new instance of a ClassLoader that the provider may

--- a/api/src/main/java/jakarta/persistence/spi/Transformer.java
+++ b/api/src/main/java/jakarta/persistence/spi/Transformer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+package jakarta.persistence.spi;
+
+import java.security.ProtectionDomain;
+
+/**
+ * A persistence provider supplies an instance of this
+ * interface to the {@link PersistenceUnitInfo#addTransformer
+ * PersistenceUnitInfo.addTransformer}
+ * method. The supplied transformer instance will get
+ * called to transform entity class files when they are
+ * loaded or redefined. The transformation occurs before
+ * the class is defined by the JVM.
+ *
+ * @since 3.1
+ */
+public interface Transformer {
+
+    /**
+     * Invoked when a class is being loaded or redefined.
+     * The implementation of this method may transform the
+     * supplied class file and return a new replacement class
+     * file.
+     *
+     * @param className  the name of the class in the internal form
+     *        of fully qualified class and interface names
+     * @param loader  the defining loader of the class to be
+     *        transformed, may be null if the bootstrap loader
+     * @param classBeingRedefined  if this is a redefine, the
+     *        class being redefined, otherwise null
+     * @param protectionDomain  the protection domain of the
+     *        class being defined or redefined
+     * @param classfileBuffer  the input byte buffer in class
+     *        file format - must not be modified
+     * @return a well-formed class file buffer (the result of
+     *         the transform), or null if no transform is performed
+     * @throws TransformerException  if the input does
+     *         not represent a well-formed class file
+     */
+    byte[] transform(String className,
+                     ClassLoader loader,
+                     Class<?> classBeingRedefined,
+                     ProtectionDomain protectionDomain,
+                     byte[] classfileBuffer)
+        throws TransformerException;
+}

--- a/api/src/main/java/jakarta/persistence/spi/TransformerException.java
+++ b/api/src/main/java/jakarta/persistence/spi/TransformerException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package jakarta.persistence.spi;
+
+/**
+ *
+ * @since 3.1
+ */
+public class TransformerException extends Exception {
+
+    /**
+     * Constructs a new <code>TransformerException</code> exception
+     * with <code>null</code> as its detail message.
+     */
+    public TransformerException() {
+        super();
+    }
+
+    /**
+     * Constructs a new <code>TransformerException</code> exception
+     * with the specified detail message.
+     *
+     * @param message the detail message.
+     */
+    public TransformerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new <code>TransformerException</code> exception
+     * with the specified detail message and cause.
+     *
+     * @param message the detail message.
+     * @param cause the cause.
+     */
+    public TransformerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new <code>TransformerException</code> exception
+     * with the specified cause.
+     *
+     * @param cause the cause.
+     */
+    public TransformerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,7 +13,7 @@
 module jakarta.persistence {
 
     requires java.logging;
-    requires transitive java.instrument;
+    requires static java.instrument;
     requires transitive java.sql;
 
     exports jakarta.persistence;

--- a/spec/src/main/asciidoc/appendixes.adoc
+++ b/spec/src/main/asciidoc/appendixes.adoc
@@ -76,3 +76,5 @@ References to schema versions lower than 2.2 were removed.
 === Jakarta Persistence 3.1
 
 EntityManagerFactory and EntityManager interfaces extend java.lang.AutoCloseable interface
+
+Supersede ClassTransformer interface by Transformer interface and make implementation of ClassTransformer explicitly optional

--- a/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
+++ b/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
+// Copyright (c) 2017, 2021 Contributors to the Eclipse Foundation
 //
 
 == Container and Provider Contracts for Deployment and Bootstrapping
@@ -1002,7 +1002,7 @@ public interface PersistenceUnitInfo {
      * @param transformer   provider-supplied transformer that the
      * container invokes at class-(re)definition time
      */
-    public void addTransformer(ClassTransformer transformer);
+    public void addTransformer(Transformer transformer);
 
     /**
      * Return a new instance of a ClassLoader that the provider may
@@ -1140,19 +1140,16 @@ public enum ValidationMode {
 }
 ----
 
-==== jakarta.persistence.spi.ClassTransformer Interface
+==== jakarta.persistence.spi.Transformer Interface
 
-The _jakarta.persistence.spi.ClassTransformer_
+The _jakarta.persistence.spi.Transformer_
 interface is implemented by a persistence provider that wants to
 transform entities and managed classes at class load time or at class
 redefinition time.
 
 [source,java]
 ----
-package jakarta.persistence.spi;
-
 import java.security.ProtectionDomain;
-import java.lang.instrument.IllegalClassFormatException;
 
 /**
  * A persistence provider supplies an instance of this
@@ -1163,9 +1160,9 @@ import java.lang.instrument.IllegalClassFormatException;
  * loaded or redefined. The transformation occurs before
  * the class is defined by the JVM.
  *
- * @since 1.0
+ * @since 3.1
  */
-public interface ClassTransformer {
+public interface Transformer {
 
     /**
      * Invoked when a class is being loaded or redefined.
@@ -1173,10 +1170,10 @@ public interface ClassTransformer {
      * supplied class file and return a new replacement class
      * file.
      *
-     * @param loader  the defining loader of the class to be
-     *        transformed, may be null if the bootstrap loader
      * @param className  the name of the class in the internal form
      *        of fully qualified class and interface names
+     * @param loader  the defining loader of the class to be
+     *        transformed, may be null if the bootstrap loader
      * @param classBeingRedefined  if this is a redefine, the
      *        class being redefined, otherwise null
      * @param protectionDomain  the protection domain of the
@@ -1185,14 +1182,74 @@ public interface ClassTransformer {
      *        file format - must not be modified
      * @return a well-formed class file buffer (the result of
      *         the transform), or null if no transform is performed
-     * @throws IllegalClassFormatException  if the input does
+     * @throws TransformerException  if the input does
+     *         not represent a well-formed class file
+     */
+    byte[] transform(String className,
+                     ClassLoader loader,
+                     Class<?> classBeingRedefined,
+                     ProtectionDomain protectionDomain,
+                     byte[] classfileBuffer)
+        throws TransformerException;
+}
+----
+
+==== jakarta.persistence.spi.ClassTransformer Interface
+
+The _jakarta.persistence.spi.ClassTransformer_
+interface is implemented by a persistence provider that wants to
+transform entities and managed classes at class load time or at class
+redefinition time. Implementation of this interface by a persistence
+provider is optional.
+
+[source,java]
+----
+package jakarta.persistence.spi;
+
+import java.security.ProtectionDomain;
+import java.lang.instrument.IllegalClassFormatException;
+
+/**
+ * A persistence provider supplies an instance of this 
+ * interface to the {@link PersistenceUnitInfo#addTransformer 
+ * PersistenceUnitInfo.addTransformer}
+ * method. The supplied transformer instance will get 
+ * called to transform entity class files when they are 
+ * loaded or redefined. The transformation occurs before  
+ * the class is defined by the JVM.
+ *
+ * @since 1.0
+ * @deprecated Use {@link Transformer}.
+ */
+@Deprecated
+public interface ClassTransformer extends Transformer {
+
+    /**
+     * Invoked when a class is being loaded or redefined.
+     * The implementation of this method may transform the 
+     * supplied class file and return a new replacement class 
+     * file.
+     *
+     * @param loader  the defining loader of the class to be 
+     *        transformed, may be null if the bootstrap loader
+     * @param className  the name of the class in the internal form 
+     *        of fully qualified class and interface names 
+     * @param classBeingRedefined  if this is a redefine, the 
+     *        class being redefined, otherwise null
+     * @param protectionDomain  the protection domain of the 
+     *        class being defined or redefined
+     * @param classfileBuffer  the input byte buffer in class 
+     *        file format - must not be modified 
+     * @return a well-formed class file buffer (the result of 
+     *         the transform), or null if no transform is performed
+     * @throws IllegalClassFormatException  if the input does 
      *         not represent a well-formed class file
      */
     byte[] transform(ClassLoader loader,
                      String className,
                      Class<?> classBeingRedefined,
-                     ProtectionDomain protectionDomain,
-                     byte[] classfileBuffer)
+                     ProtectionDomain protectionDomain, 
+                     byte[] classfileBuffer) 
         throws IllegalClassFormatException;
 }
 ----


### PR DESCRIPTION
Making dependency on `java.instrument`/`java.lang.instrument.IllegalClassFormatException` optional by introducing new `Transformer` interface superseding current `ClassTransformer` interface, which has been deprecated. Specification has been updated to make implementation of  `ClassTransformer` by the persistence provider explicitly optional.