### PR TITLE
introduce several "missing" numeric functions

### DIFF
--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
@@ -542,6 +542,14 @@ public interface CriteriaBuilder {
 	
 
     //numerical operations:
+
+    /**
+     * Create an expression that returns the sign of its
+     * argument.
+     * @param x expression
+     * @return sign
+     */
+    Expression<Integer> sign(Expression<? extends Number> x);
 	
     /**
      * Create an expression that returns the arithmetic negation
@@ -558,7 +566,22 @@ public interface CriteriaBuilder {
      * @return absolute value
      */
     <N extends Number> Expression<N> abs(Expression<N> x);
-	
+
+    /**
+     * Create an expression that returns the ceiling of its
+     * argument.
+     * @param x expression
+     * @return ceiling
+     */
+    <N extends Number> Expression<N> ceiling(Expression<N> x);
+
+    /**
+     * Create an expression that returns the floor of its
+     * argument.
+     * @param x expression
+     * @return floor
+     */
+    <N extends Number> Expression<N> floor(Expression<N> x);
     /**
      * Create an expression that returns the sum
      * of its arguments.
@@ -702,7 +725,51 @@ public interface CriteriaBuilder {
      */	
     Expression<Double> sqrt(Expression<? extends Number> x);
 
-	
+    /**
+     * Create an expression that returns the exponential
+     * of its argument.
+     * @param x expression
+     * @return exponential
+     */
+    Expression<Double> exp(Expression<? extends Number> x);
+
+    /**
+     * Create an expression that returns the natural logarithm
+     * of its argument.
+     * @param x expression
+     * @return natural logarithm
+     */
+    Expression<Double> ln(Expression<? extends Number> x);
+
+    /**
+     * Create an expression that returns the first argument
+     * raised to the power of its second argument.
+     * @param x base
+     * @param y exponent
+     * @return the base raised to the power of the exponent
+     */
+    Expression<Double> power(Expression<? extends Number> x, Expression<? extends Number> y);
+
+    /**
+     * Create an expression that returns the first argument
+     * raised to the power of its second argument.
+     * @param x base
+     * @param y exponent
+     * @return the base raised to the power of the exponent
+     */
+    Expression<Double> power(Expression<? extends Number> x, Number y);
+
+    /**
+     * Create an expression that returns the first argument
+     * rounded to the number of decimal places given by the
+     * second argument.
+     * @param x base
+     * @param n number of decimal places
+     * @return the rounded value
+     */
+    <T extends Number> Expression<T> round(Expression<T> x, Integer n);
+
+
     //typecasts:
     
     /**

--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
@@ -545,7 +545,9 @@ public interface CriteriaBuilder {
 
     /**
      * Create an expression that returns the sign of its
-     * argument.
+     * argument, that is, {@code 1} if its argument is
+     * positive, {@code -1} if its argument is negative,
+     * or {@code 0} if its argument is exactly zero.
      * @param x expression
      * @return sign
      */
@@ -569,7 +571,8 @@ public interface CriteriaBuilder {
 
     /**
      * Create an expression that returns the ceiling of its
-     * argument.
+     * argument, that is, the smallest integer greater than
+     * or equal to its argument.
      * @param x expression
      * @return ceiling
      */
@@ -577,7 +580,8 @@ public interface CriteriaBuilder {
 
     /**
      * Create an expression that returns the floor of its
-     * argument.
+     * argument, that is, the largest integer smaller than
+     * or equal to its argument.
      * @param x expression
      * @return floor
      */
@@ -692,7 +696,8 @@ public interface CriteriaBuilder {
 	
     /**
      * Create an expression that returns the modulus
-     * of its arguments.
+     * (remainder under integer division) of its
+     * arguments.
      * @param x expression
      * @param y expression
      * @return modulus
@@ -701,7 +706,8 @@ public interface CriteriaBuilder {
 	
     /**
      * Create an expression that returns the modulus
-     * of its arguments.
+     * (remainder under integer division) of its
+     * arguments.
      * @param x expression
      * @param y value
      * @return modulus
@@ -710,7 +716,8 @@ public interface CriteriaBuilder {
 
     /**
      * Create an expression that returns the modulus
-     * of its arguments.
+     * (remainder under integer division) of its
+     * arguments.
      * @param x value
      * @param y expression
      * @return modulus
@@ -727,7 +734,8 @@ public interface CriteriaBuilder {
 
     /**
      * Create an expression that returns the exponential
-     * of its argument.
+     * of its argument, that is, Euler's number <i>e</i>
+     * raised to the power of its argument.
      * @param x expression
      * @return exponential
      */

--- a/spec/src/main/asciidoc/ch04-query-language.adoc
+++ b/spec/src/main/asciidoc/ch04-query-language.adoc
@@ -314,18 +314,19 @@ which the method _Character.isJavaIdentifierPart_ returns true. The
 question mark (_?_) character is reserved for use by the Jakarta
 Persistence query language.
 
-The following are reserved identifiers: ABS,
-ALL, AND, ANY, AS, ASC, AVG, BETWEEN, BIT_LENGTHfootnote:[BIT_LENGTH,
-CHAR_LENGTH, CHARACTER_LENGTH, POSITION, and UNKNOWN are not currently
-used: they are reserved for future use.],
-BOTH, BY, CASE, CHAR_LENGTH, CHARACTER_LENGTH, CLASS, COALESCE, CONCAT,
-COUNT, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DELETE, DESC,
-DISTINCT, ELSE, EMPTY, END, ENTRY, ESCAPE, EXISTS, EXTRACT, FALSE, FETCH,
-FROM, FUNCTION, GROUP, HAVING, IN, INDEX, INNER, IS, JOIN, KEY, LEADING,
-LEFT, LENGTH, LIKE, LOCAL, LOCATE, LOWER, MAX, MEMBER, MIN, MOD, NEW, NOT, NULL,
-NULLIF, OBJECT, OF, ON, OR, ORDER, OUTER, POSITION, SELECT, SET, SIZE,
-SOME, SQRT, SUBSTRING, SUM, THEN, TRAILING, TREAT, TRIM, TRUE, TYPE,
-UNKNOWN, UPDATE, UPPER, VALUE, WHEN, WHERE.
+The followingfootnote:[BIT_LENGTH, CHAR_LENGTH, CHARACTER_LENGTH,
+POSITION, and UNKNOWN are not currently used: they are reserved for
+future use.] are reserved identifiers: ABS, ALL, AND, ANY, AS, ASC,
+AVG, BETWEEN, BIT_LENGTH, BOTH, BY, CASE, CEILING, CHAR_LENGTH,
+CHARACTER_LENGTH, CLASS, COALESCE, CONCAT, COUNT, CURRENT_DATE,
+CURRENT_TIME, CURRENT_TIMESTAMP, DELETE, DESC, DISTINCT, ELSE, EMPTY,
+END, ENTRY, ESCAPE, EXISTS, EXP, EXTRACT, FALSE, FETCH, FLOOR, FROM,
+FUNCTION, GROUP, HAVING, IN, INDEX, INNER, IS, JOIN, KEY, LEADING,
+LEFT, LENGTH, LIKE, LOCAL, LN, LOCATE, LOWER, MAX, MEMBER, MIN, MOD,
+NEW, NOT, NULL, NULLIF, OBJECT, OF, ON, OR, ORDER, OUTER, POSITION,
+POWER, ROUND, SELECT, SET, SIGN, SIZE, SOME, SQRT, SUBSTRING, SUM,
+THEN, TRAILING, TREAT, TRIM, TRUE, TYPE, UNKNOWN, UPDATE, UPPER,
+VALUE, WHEN, WHERE.
 
 Reserved identifiers are case insensitive.
 Reserved identifiers must not be used as identification variables or
@@ -1730,20 +1731,35 @@ string in characters as an integer.
 ----
 functions_returning_numerics ::=
     ABS(arithmetic_expression) |
-    SQRT(arithmetic_expression) |
+    CEILING(arithmetic_expression) |
+    EXP(arithmetic_expression) |
+    FLOOR(arithmetic_expression) |
+    LN(arithmetic_expression) |
     MOD(arithmetic_expression, arithmetic_expression) |
+    POWER(arithmetic_expression, arithmetic_expression) |
+    ROUND(arithmetic_expression, arithmetic_expression) |
+    SIGN(arithmetic_expression) |
+    SQRT(arithmetic_expression) |
     SIZE(collection_valued_path_expression) |
     INDEX(identification_variable) |
     extract_datetime_field
 ----
 
-The ABS function takes a numeric argument and
-returns a number (integer, float, or double) of the same type as the
-argument to the function.
+The ABS, CEILING, and FLOOR functions accept a numeric argument and
+return a number (integer, float, or double) of the same type as the
+argument.
 
-The SQRT function takes a numeric argument and returns a double.
+The SIGN function accepts a numeric argument and returns an integer.
 
-The MOD function takes two integer arguments and returns an integer.
+The SQRT, EXP, and LN functions accept a numeric argument and return
+a double.
+
+The MOD function accepts two integer arguments and returns an integer.
+
+The ROUND function accepts a numeric argument and an integer argument
+and returns a number of the same type as the first argument.
+
+The POWER function accepts two numeric arguments and returns a double.
 
 Numeric arguments to these functions may
 correspond to the numeric Java object types as well as the primitive
@@ -3101,8 +3117,15 @@ functions_returning_numerics ::=
     LENGTH(string_expression) |
     LOCATE(string_expression, string_expression[, arithmetic_expression]) |
     ABS(arithmetic_expression) |
+    CEILING(arithmetic_expression) |
+    EXP(arithmetic_expression) |
+    FLOOR(arithmetic_expression) |
+    LN(arithmetic_expression) |
+    SIGN(arithmetic_expression) |
     SQRT(arithmetic_expression) |
     MOD(arithmetic_expression, arithmetic_expression) |
+    POWER(arithmetic_expression, arithmetic_expression) |
+    ROUND(arithmetic_expression, arithmetic_expression) |
     SIZE(collection_valued_path_expression) |
     INDEX(identification_variable) |
     extract_datetime_field


### PR DESCRIPTION
This adds `sign()`, `exp()`, `power()`, `ln()`, `round()`, `floor()`, `ceiling()` to the list of functions portably supported in JPQL. Each of these functions (or something very similar) is available on essentially every SQL database, and are needed in any language which is intended to be used for any sort of nontrivial data analysis. In particular, the natural logarithm and functions for rounding are pretty essential.

I have (against my own preference) *not* included trigonometric functions.