### PR TITLE
introduce local date/time special functions

### DIFF
--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
@@ -1246,6 +1246,24 @@ public interface CriteriaBuilder {
      *  @return expression for current time
      */	
     Expression<java.sql.Time> currentTime();
+
+    /**
+     *  Create expression to return current local date.
+     *  @return expression for current date
+     */
+    Expression<java.time.LocalDate> localDate();
+
+    /**
+     *  Create expression to return current local datetime.
+     *  @return expression for current timestamp
+     */
+    Expression<java.time.LocalDateTime> localDateTime();
+
+    /**
+     *  Create expression to return current local time.
+     *  @return expression for current time
+     */
+    Expression<java.time.LocalTime> localTime();
 	
 
     //in builders:

--- a/spec/src/main/asciidoc/ch04-query-language.adoc
+++ b/spec/src/main/asciidoc/ch04-query-language.adoc
@@ -322,7 +322,7 @@ BOTH, BY, CASE, CHAR_LENGTH, CHARACTER_LENGTH, CLASS, COALESCE, CONCAT,
 COUNT, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP, DELETE, DESC,
 DISTINCT, ELSE, EMPTY, END, ENTRY, ESCAPE, EXISTS, EXTRACT, FALSE, FETCH,
 FROM, FUNCTION, GROUP, HAVING, IN, INDEX, INNER, IS, JOIN, KEY, LEADING,
-LEFT, LENGTH, LIKE, LOCATE, LOWER, MAX, MEMBER, MIN, MOD, NEW, NOT, NULL,
+LEFT, LENGTH, LIKE, LOCAL, LOCATE, LOWER, MAX, MEMBER, MIN, MOD, NEW, NOT, NULL,
 NULLIF, OBJECT, OF, ON, OR, ORDER, OUTER, POSITION, SELECT, SET, SIZE,
 SOME, SQRT, SUBSTRING, SUM, THEN, TRAILING, TREAT, TRIM, TRUE, TYPE,
 UNKNOWN, UPDATE, UPPER, VALUE, WHEN, WHERE.
@@ -1776,12 +1776,21 @@ functions_returning_datetime :=
     CURRENT_DATE |
     CURRENT_TIME |
     CURRENT_TIMESTAMP |
+    LOCAL DATE |
+    LOCAL TIME |
+    LOCAL DATETIME |
     extract_datetime_part
 ----
 
+The functions LOCAL DATE, LOCAL TIME, and LOCAL DATETIME return the value
+of the current date, time, or timestamp on the database server, respectively.
+Their types are _java.time.LocalDate_, _java.time.LocalTime_, and
+_java.time.LocalDateTime_ respectively.
+
 The functions CURRENT_DATE, CURRENT_TIME, and CURRENT_TIMESTAMP
 return the value of the current date, time, or timestamp on the database
-server, respectively.
+server, respectively. Their types are _java.sql.Date_, _java.sql.Time_,
+and _java.sql.Timestamp_ respectively.
 
 The EXTRACT function takes a datetime argument and one of the following
 field type identifiers: YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE,
@@ -1830,7 +1839,7 @@ part to EXTRACT.
 
 [source,sql]
 ----
-FROM Course c WHERE c.year = EXTRACT(YEAR FROM CURRENT_DATE)
+FROM Course c WHERE c.year = EXTRACT(YEAR FROM LOCAL DATE)
 ----
 
 ===== Invocation of Predefined and User-defined Database Functions [[a5311]]
@@ -3096,6 +3105,9 @@ functions_returning_datetime ::=
     CURRENT_DATE |
     CURRENT_TIME |
     CURRENT_TIMESTAMP |
+    LOCAL DATE |
+    LOCAL TIME |
+    LOCAL DATETIME |
     extract_datetime_part
 functions_returning_strings ::=
     CONCAT(string_expression, string_expression{, string_expression}*) |


### PR DESCRIPTION
This finally puts support for the `LocalDate`, `LocalTime`, and `LocalDateTime` types defined by `java.time` on an equal footing to support for the bad old `Date`,`Time`,`Timestamp` classes in `java.sql`.

It also clarifies the types of `current_date` and friends, which were left undefined until now, but which were interpreted by implementations to mean the `java.sql` types.