### PR TITLE
Apply same fix from platform-tck#2463 to Persistence TCK

### DIFF
--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
@@ -266,8 +266,8 @@ public class Client1 extends Client {
 			getEntityTransaction().begin();
 			getEntityManager().persist(new Int_Field("1"));
 			getEntityManager().persist(new Int_Property("2"));
-			getEntityManager().persist(new Integer_Field("3", new Integer(0)));
-			getEntityManager().persist(new Integer_Property("4", new Integer(0)));
+			getEntityManager().persist(new Integer_Field("3"));
+			getEntityManager().persist(new Integer_Property("4"));
 
 			getEntityTransaction().commit();
 		} catch (Exception e) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
@@ -264,8 +264,8 @@ public class Client2 extends Client {
 			getEntityTransaction().begin();
 			getEntityManager().persist(new Short_Field("1"));
 			getEntityManager().persist(new Short_Property("2"));
-			getEntityManager().persist(new ShortClass_Field("3", new Short((short) 0)));
-			getEntityManager().persist(new ShortClass_Property("4", new Short((short) 0)));
+			getEntityManager().persist(new ShortClass_Field("3"));
+			getEntityManager().persist(new ShortClass_Property("4"));
 			getEntityTransaction().commit();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected Exception in createShortTestData:", e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
@@ -264,8 +264,8 @@ public class Client3 extends Client {
 			getEntityTransaction().begin();
 			getEntityManager().persist(new Long_Field("1"));
 			getEntityManager().persist(new Long_Property("2"));
-			getEntityManager().persist(new LongClass_Field("3", new Long(0)));
-			getEntityManager().persist(new LongClass_Property("4", new Long(0)));
+			getEntityManager().persist(new LongClass_Field("3"));
+			getEntityManager().persist(new LongClass_Property("4"));
 			getEntityTransaction().commit();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected Exception in createLongTestData:", e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
@@ -176,8 +176,8 @@ public class Client4 extends Client {
 		try {
 			getEntityTransaction().begin();
 			Timestamp currentTime = new Timestamp(new Date().getTime());
-			getEntityManager().persist(new Timestamp_Field("1", currentTime));
-			getEntityManager().persist(new Timestamp_Property("2", currentTime));
+			getEntityManager().persist(new Timestamp_Field("1"));
+			getEntityManager().persist(new Timestamp_Property("2"));
 			getEntityTransaction().commit();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected Exception in createTimestampTestData:", e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Integer_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Integer_Field.java
@@ -45,12 +45,6 @@ public class Integer_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Integer_Field(String id, Integer basicInteger) {
-
-		this.id = id;
-		this.basicInteger = basicInteger;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Integer_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Integer_Property.java
@@ -39,12 +39,6 @@ public class Integer_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Integer_Property(String id, Integer basicInteger) {
-
-		this.id = id;
-		this.basicInteger = basicInteger;
-	}
-
 	@Id
 	public String getId() {
 		return id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/LongClass_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/LongClass_Field.java
@@ -50,12 +50,6 @@ public class LongClass_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public LongClass_Field(String id, Long value) {
-
-		this.id = id;
-		this.basicLong = value;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/LongClass_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/LongClass_Property.java
@@ -44,12 +44,6 @@ public class LongClass_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public LongClass_Property(String id, Long value) {
-
-		this.id = id;
-		this.basicLong = value;
-	}
-
 	@Id
 	public String getId() {
 		return id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Long_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Long_Field.java
@@ -50,12 +50,6 @@ public class Long_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Long_Field(String id, long value) {
-
-		this.id = id;
-		this.basicLong = value;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Long_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Long_Property.java
@@ -44,12 +44,6 @@ public class Long_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Long_Property(String id, long value) {
-
-		this.id = id;
-		this.basicLong = value;
-	}
-
 	@Id
 	public String getId() {
 		return id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/ShortClass_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/ShortClass_Field.java
@@ -50,12 +50,6 @@ public class ShortClass_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public ShortClass_Field(String id, Short value) {
-
-		this.id = id;
-		this.basicShort = value;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/ShortClass_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/ShortClass_Property.java
@@ -44,12 +44,6 @@ public class ShortClass_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public ShortClass_Property(String id, Short value) {
-
-		this.id = id;
-		this.basicShort = value;
-	}
-
 	@Id
 	public String getId() {
 		return id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Short_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Short_Field.java
@@ -50,12 +50,6 @@ public class Short_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Short_Field(String id, short value) {
-
-		this.id = id;
-		this.basicShort = value;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Short_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Short_Property.java
@@ -44,12 +44,6 @@ public class Short_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Short_Property(String id, short value) {
-
-		this.id = id;
-		this.basicShort = value;
-	}
-
 	@Id
 	public String getId() {
 		return id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Timestamp_Field.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Timestamp_Field.java
@@ -47,12 +47,6 @@ public class Timestamp_Field implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Timestamp_Field(String id, Timestamp basicTimestamp) {
-
-		this.id = id;
-		this.basicTimestamp = basicTimestamp;
-	}
-
 	public String getId() {
 		return id;
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Timestamp_Property.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Timestamp_Property.java
@@ -41,12 +41,6 @@ public class Timestamp_Property implements java.io.Serializable {
 		this.id = id;
 	}
 
-	public Timestamp_Property(String id, Timestamp basicTimestamp) {
-
-		this.id = id;
-		this.basicTimestamp = basicTimestamp;
-	}
-
 	@Id
 	public String getId() {
 		return id;


### PR DESCRIPTION
This change copies the fix from [jakartaee/platform-tck#2463](https://github.com/jakartaee/platform-tck/pull/2463)
 into the standalone Persistence TCK.
It resolves the same issue that was previously addressed in the Platform TCK’s persistence-outside-container tests.

The purpose is to keep both TCK sources consistent while the Persistence TCK transition is underway.
