### PR TITLE
improve javadoc surrounding optimistic locking

### DIFF
--- a/api/src/main/java/jakarta/persistence/Entity.java
+++ b/api/src/main/java/jakarta/persistence/Entity.java
@@ -65,7 +65,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * annotated {@link Id} or {@link EmbeddedId} holding the primary key
  * of the entity. An entity class may optionally have a field or
  * property annotated {@link Version}, which holds a value used to
- * detect optimistic lock failure.
+ * detect optimistic locking conflicts.
  *
  * <p>Fields or properties of an entity class are persistent by default.
  * The {@link Transient} annotation or the Java {@code transient} keyword

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -200,7 +200,7 @@ public interface EntityManager extends AutoCloseable {
      * This operation cascades to every entity related by an association
      * marked {@link CascadeType#PERSIST cascade=PERSIST}. If the given
      * entity instance is already managed, that is, if it already belongs
-     * to this persistence context, and has not been marked for removal,
+     * to this persistence context and has not been marked for removal,
      * it is itself ignored, but the operation still cascades.
      * @param entity  a new, managed, or removed entity instance
      * @throws EntityExistsException if the given entity is detached
@@ -227,7 +227,7 @@ public interface EntityManager extends AutoCloseable {
      * operation cascades to every entity related by an association
      * marked {@link CascadeType#MERGE cascade=MERGE}. If the given
      * entity instance is managed, that is, if it belongs to this
-     * persistence context, and has not been marked for removal, it is
+     * persistence context and has not been marked for removal, it is
      * itself ignored, but the operation still cascades, and it is
      * returned directly.
      * @param entity  a new, managed, or detached entity instance
@@ -237,6 +237,10 @@ public interface EntityManager extends AutoCloseable {
      * @throws TransactionRequiredException if there is no transaction
      *         when invoked on a container-managed entity manager of
      *         that is of type {@link PersistenceContextType#TRANSACTION}
+     * @throws OptimisticLockException if an optimistic locking conflict
+     *         is detected (note that optimistic version checking might be
+     *         deferred until changes are flushed to the database)
+     *
      */
     <T> T merge(T entity);
 
@@ -255,6 +259,9 @@ public interface EntityManager extends AutoCloseable {
      *         container-managed entity manager of type
      *         {@link PersistenceContextType#TRANSACTION} and there is
      *         no transaction
+     * @throws OptimisticLockException if an optimistic locking conflict
+     *         is detected (note that optimistic version checking might be
+     *         deferred until changes are flushed to the database)
      */
     void remove(Object entity);
     
@@ -268,7 +275,7 @@ public interface EntityManager extends AutoCloseable {
      * @return the found entity instance or null if the entity does
      *         not exist
      * @throws IllegalArgumentException if the first argument does
-     *         not denote an entity type or if the second argument is
+     *         not denote an entity type, or if the second argument is
      *         not a valid type for that entity's primary key or is
      *         null
      */
@@ -288,7 +295,7 @@ public interface EntityManager extends AutoCloseable {
      * @return the found entity instance or null if the entity does
      *         not exist
      * @throws IllegalArgumentException if the first argument does 
-     *         not denote an entity type or if the second argument
+     *         not denote an entity type, or if the second argument
      *         is not a valid type for that entity's primary key or
      *         is null
      * @since 2.0
@@ -299,7 +306,7 @@ public interface EntityManager extends AutoCloseable {
     /**
      * Find by primary key and obtain the given lock type for the
      * resulting entity. Search for an entity of the specified class and
-     * primary key, and lock it with respect to the specified lock type.
+     * primary key and lock it with respect to the specified lock type.
      * If the entity instance is contained in the persistence context,
      * it is returned from there, and the effect of this method is the
      * same as if the {@link #lock} method had been called on the entity.
@@ -308,7 +315,7 @@ public interface EntityManager extends AutoCloseable {
      * attribute, the persistence provider must perform optimistic
      * version checks when obtaining the database lock. If these checks
      * fail, the {@link OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -322,7 +329,7 @@ public interface EntityManager extends AutoCloseable {
      * @return the found entity instance or null if the entity does
      *         not exist
      * @throws IllegalArgumentException if the first argument does
-     *         not denote an entity type or the second argument is
+     *         not denote an entity type, or the second argument is
      *         not a valid type for that entity's primary key or
      *         is null
      * @throws TransactionRequiredException if there is no 
@@ -345,7 +352,7 @@ public interface EntityManager extends AutoCloseable {
     /**
      * Find by primary key and lock the entity, using the specified
      * properties. Search for an entity of the specified class and
-     * primary key, and lock it with respect to the specified lock type.
+     * primary key and lock it with respect to the specified lock type.
      * If the entity instance is contained in the persistence context,
      * it is returned from there.  
      * <p> If the entity is found within the persistence context and
@@ -353,7 +360,7 @@ public interface EntityManager extends AutoCloseable {
      * attribute, the persistence provider must perform optimistic
      * version checks when obtaining the database lock. If these checks
      * fail, the {@link OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -375,7 +382,7 @@ public interface EntityManager extends AutoCloseable {
      * @return the found entity instance or null if the entity does
      *         not exist
      * @throws IllegalArgumentException if the first argument does
-     *         not denote an entity type or the second argument is
+     *         not denote an entity type, or the second argument is
      *         not a valid type for that entity's primary key or
      *         is null
      * @throws TransactionRequiredException if there is no 
@@ -407,9 +414,9 @@ public interface EntityManager extends AutoCloseable {
      * <p>If the entity is found within the persistence context and
      * the lock mode type is pessimistic and the entity has a version
      * attribute, the persistence provider must perform optimistic
-     * version checks when obtaining the database lock.  If these checks
+     * version checks when obtaining the database lock. If these checks
      * fail, the {@code OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@code PessimisticLockException} is thrown if the
@@ -465,7 +472,7 @@ public interface EntityManager extends AutoCloseable {
      * attribute, the persistence provider must perform optimistic
      * version checks when obtaining the database lock. If these checks
      * fail, the {@code OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -519,13 +526,13 @@ public interface EntityManager extends AutoCloseable {
      * association to an entity without loading its state from the
      * database.
      * <p>The application should not expect the instance state to
-     * be available upon detachment, unless it was accessed by the
+     * be available upon detachment unless it was accessed by the
      * application while the entity manager was open.
      * @param entityClass  entity class
      * @param primaryKey  primary key
      * @return a reference to the entity instance
      * @throws IllegalArgumentException if the first argument does
-     *         not denote an entity type or the second argument is
+     *         not denote an entity type, or the second argument is
      *         not a valid type for that entity's primary key or
      *         is null
      * @throws EntityNotFoundException if the entity state cannot
@@ -548,7 +555,7 @@ public interface EntityManager extends AutoCloseable {
      * association to an entity without loading its state from the
      * database.
      * <p>The application should not expect the instance state to
-     * be available upon detachment, unless it was accessed by the
+     * be available upon detachment unless it was accessed by the
      * application while the entity manager was open.
      * @param entity  a persistent or detached entity instance
      * @return a reference to the entity instance
@@ -567,6 +574,8 @@ public interface EntityManager extends AutoCloseable {
      *        no transaction or if the entity manager has not been
      *        joined to the current transaction
      * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected
      */
     void flush();
 
@@ -592,7 +601,7 @@ public interface EntityManager extends AutoCloseable {
      * also perform optimistic version checks when obtaining the 
      * database lock. If these checks fail, the
      * {@link OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -629,7 +638,7 @@ public interface EntityManager extends AutoCloseable {
      * also perform optimistic version checks when obtaining the 
      * database lock. If these checks fail, the
      * {@link OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -675,7 +684,7 @@ public interface EntityManager extends AutoCloseable {
      * also perform optimistic version checks when obtaining the
      * database lock. If these checks fail, the
      * {@link OptimisticLockException} is thrown.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -759,7 +768,7 @@ public interface EntityManager extends AutoCloseable {
      * if any, and obtain the given {@linkplain LockModeType lock mode}.
      * This operation cascades to every entity related by an association
      * marked {@link CascadeType#REFRESH cascade=REFRESH}.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -798,7 +807,7 @@ public interface EntityManager extends AutoCloseable {
      * using the specified properties. This operation cascades to every
      * entity related by an association marked {@link CascadeType#REFRESH
      * cascade=REFRESH}.
-     * <p>If the lock mode type is pessimistic and the entity instance
+     * <p>If the lock mode type is pessimistic, and the entity instance
      * is found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -847,7 +856,7 @@ public interface EntityManager extends AutoCloseable {
      * obtaining the given lock mode. This operation cascades to every
      * entity related by an association marked {@link CascadeType#REFRESH
      * cascade=REFRESH}.
-     * <p>If the lock mode type is pessimistic and the entity instance is
+     * <p>If the lock mode type is pessimistic, and the entity instance is
      * found but cannot be locked:
      * <ul>
      * <li>the {@link PessimisticLockException} is thrown if the
@@ -926,7 +935,7 @@ public interface EntityManager extends AutoCloseable {
      * @param entity  a managed entity instance
      * @return the lock mode currently held
      * @throws TransactionRequiredException if there is no active
-     *         transaction or if the entity manager has not been
+     *         transaction, or if the entity manager has not been
      *         joined to the current transaction
      * @throws IllegalArgumentException if a transaction is active
      *         but the given instance is not a managed entity

--- a/api/src/main/java/jakarta/persistence/OptimisticLockException.java
+++ b/api/src/main/java/jakarta/persistence/OptimisticLockException.java
@@ -26,6 +26,8 @@ package jakarta.persistence;
  * @see EntityManager#find(Class, Object, LockModeType, java.util.Map)
  * @see EntityManager#lock(Object, LockModeType)
  * @see EntityManager#lock(Object, LockModeType, java.util.Map)
+ * @see EntityManager#merge(Object)
+ * @see EntityManager#flush()
  * 
  * @since 1.0
  */

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -38,7 +38,8 @@ public interface Query {
 
     /**
      * Execute a SELECT query and return the query results as an untyped
-     * {@link List}.
+     * {@link List}. If necessary, first synchronize changes with the
+     * database by flushing the persistence context.
      * @return a list of the results, or an empty list if there are
      *         no results
      * @throws IllegalStateException if called for a Jakarta
@@ -57,13 +58,17 @@ public interface Query {
      * @throws PersistenceException if the query execution exceeds 
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      */
     @SuppressWarnings({"rawtypes"})
     List getResultList();
 
     /**
      * Execute a SELECT query and return the query results as an untyped
-     * {@link java.util.stream.Stream}.
+     * {@link java.util.stream.Stream}. If necessary, first synchronize
+     * changes with the database by flushing the persistence context.
      *
      * <p>By default, this method delegates to {@code getResultList().stream()},
      * however persistence provider may choose to override this method
@@ -87,6 +92,9 @@ public interface Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      * @see Stream
      * @see #getResultList()
      * @since 2.2
@@ -98,6 +106,8 @@ public interface Query {
 
     /**
      * Execute a SELECT query that returns a single untyped result.
+     * If necessary, first synchronize changes with the database by
+     * flushing the persistence context.
      * @return the result
      * @throws NoResultException if there is no result
      * @throws NonUniqueResultException if more than one result
@@ -117,11 +127,16 @@ public interface Query {
      * @throws PersistenceException if the query execution exceeds 
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      */
     Object getSingleResult();
 
     /**
      * Execute a SELECT query that returns a single untyped result.
+     * If necessary, first synchronize changes with the database by
+     * flushing the persistence context.
      * @return the result, or null if there is no result
      * @throws NonUniqueResultException if more than one result
      * @throws IllegalStateException if called for a Jakarta
@@ -140,6 +155,9 @@ public interface Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      *
      * @since 3.2
      */

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -38,7 +38,8 @@ public interface TypedQuery<X> extends Query {
 	
     /**
      * Execute a SELECT query and return the query results as a typed
-     * {@link List List&lt;X&gt;}.
+     * {@link List List&lt;X&gt;}. If necessary, first synchronize
+     * changes with the database by flushing the persistence context.
      * @return a list of the results, each of type {@link X}, or an
      *         empty list if there are no results
      * @throws IllegalStateException if called for a Jakarta
@@ -62,11 +63,13 @@ public interface TypedQuery<X> extends Query {
 
     /**
      * Execute a SELECT query and return the query result as a typed
-     * {@link java.util.stream.Stream Stream&lt;X&gt;}.
+     * {@link java.util.stream.Stream Stream&lt;X&gt;}. If necessary,
+     * first synchronize changes with the database by flushing the
+     * persistence context.
      *
      * <p>By default, this method delegates to {@link List#stream()
-     * getResultList().stream()}, however, persistence provider may
-     * choose to override this method to provide additional capabilities.
+     * getResultList().stream()}. The persistence provider may choose
+     * to override this method to provide additional capabilities.
      *
      * @return a stream of the results, each of type {@link X}, or an
      *         empty stream if there are no results
@@ -86,6 +89,9 @@ public interface TypedQuery<X> extends Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      * @see Stream
      * @see #getResultList()
      * @since 2.2
@@ -96,6 +102,8 @@ public interface TypedQuery<X> extends Query {
 
     /**
      * Execute a SELECT query that returns a single result.
+     * If necessary, first synchronize changes with the database by
+     * flushing the persistence context.
      * @return the result, of type {@link X}
      * @throws NoResultException if there is no result
      * @throws NonUniqueResultException if more than one result
@@ -115,11 +123,16 @@ public interface TypedQuery<X> extends Query {
      * @throws PersistenceException if the query execution exceeds 
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      */
     X getSingleResult();
 
     /**
      * Execute a SELECT query that returns a single untyped result.
+     * If necessary, first synchronize changes with the database by
+     * flushing the persistence context.
      * @return the result, of type {@link X}, or null if there is no
      *         result
      * @throws NonUniqueResultException if more than one result
@@ -139,6 +152,9 @@ public interface TypedQuery<X> extends Query {
      * @throws PersistenceException if the query execution exceeds
      *         the query timeout value set and the transaction
      *         is rolled back
+     * @throws PersistenceException if the flush fails
+     * @throws OptimisticLockException if an optimistic locking
+     *         conflict is detected during the flush
      *
      * @since 3.2
      */

--- a/api/src/main/java/jakarta/persistence/Version.java
+++ b/api/src/main/java/jakarta/persistence/Version.java
@@ -24,12 +24,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Declares the version field or property of an entity class, which
- * is used to detect optimistic lock failures, ensuring the integrity
+ * is used to detect optimistic locking conflicts, ensuring the integrity
  * of optimistic transactions. The version field or property holds a
  * version number or timestamp identifying the revision of the entity
  * data held by an entity class instance.
  *
- * <p>An {@linkplain OptimisticLockException optimistic lock failure}
+ * <p>An {@linkplain OptimisticLockException optimistic locking conflict}
  * occurs when verification of the version or timestamp fails
  * during an attempt to update the entity, that is, if the version
  * or timestamp held in the database changes between reading the

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -715,7 +715,7 @@ of work, the version or timestamp is:
 1. read from the database when the data itself is read, and
 2. verified when the data is deleted.
 
-An _optimistic lock failure_ occurs when verification fails, that is,
+An _optimistic locking conflict_ occurs when verification fails, that is,
 if the version or timestamp held in the database changes between
 reading the data (step 1), and attempting to update or delete the data
 (step 2).
@@ -734,7 +734,7 @@ optimistic locking must specify a version field or property for each
 optimistically-locked entity using the `@Version` annotation defined in
 <<a16432>> or equivalent XML element.
 
-When an optimistic lock failure is detected, the persistence provider
+When an optimistic locking conflict is detected, the persistence provider
 must:
 
 - throw an `OptimisticLockException` and


### PR DESCRIPTION
and standardize on terminology "optimistic locking conflict" instead of "optimistic lock failure"

inspired by #601 by @quaff