### PR TITLE
Ensure getResultCount is appropriate for pagination

### DIFF
--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -68,15 +68,16 @@ public interface Query {
 
     /**
      * <p>Determine the maximum number of results that could in
-     * principle be returned by the query with no
+     * principle be returned by the query if no
      * {@linkplain #getFirstResult() offset} or
-     * {@linkplain #getMaxResults() limit} applied to the query.</p>
+     * {@linkplain #getMaxResults() limit} were applied.</p>
      *
      * <p>The {@code getResultCount} method should not cause query
      * results to be fetched from the database.</p>
      *
      * @return the maximum number of results that could in principle
-     *         be returned by the query without any offset and limit.
+     *         be returned by the query if no offset or limit were
+     *         applied
      * @throws IllegalStateException if called for a Jakarta
      *         Persistence query language UPDATE or DELETE statement
      * @throws QueryTimeoutException if the query execution exceeds


### PR DESCRIPTION
Query.getResultCount() is intended for pagination of large amounts of data, so it needs to be clear that an implementation shouldn't fetch all of the data and invoke `.size()` on the resulting `List`, which would cap the results reported at `Integer.MAX_VALUE` even though `getResultCount()` returns `long`.