### PR TITLE
Review comment on possible enhancement with a return type for fetch(association)

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityAgent.java
+++ b/api/src/main/java/jakarta/persistence/EntityAgent.java
@@ -278,14 +278,16 @@ public non-sealed interface EntityAgent extends EntityHandler {
      * Fetch an association or collection that is configured for lazy loading.
      * {@snippet :
      * Book book = agent.get(Book.class, isbn);  // book is immediately detached
-     * agent.fetch(book.getAuthors());           // fetch the associated authors
-     * book.getAuthors().forEach(author -> ... );  // iterate the collection
+     * agent.fetch(book.getAuthors())            // fetch the associated authors
+     *      .forEach(author -> ... );            // iterate the collection
      * }
      *
      * @param association a {@linkplain FetchType#LAZY lazy} association
+     * @param <T> entity attribute type that is an association
      *
+     * @return the association with its state fetched.
      * @throws PersistenceException if a record could not be
      *         read from the database
      */
-    void fetch(Object association);
+    <T> T fetch(T association);
 }


### PR DESCRIPTION
An optional [review comment](https://github.com/jakartaee/persistence/pull/795#issuecomment-3647181286) that was deferred from #795

Usage of entityAgent.fetch(association) could be slightly more convenient in some cases if it returned the association.  See update to code example in method Javadoc.

If this isn't wanted, just close it.