### PR TITLE
Add apiNote tag configuration

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -355,6 +355,13 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                             <packages>jakarta.persistence*</packages>
                         </group>
                     </groups>
+                    <tags>
+                        <tag>
+                            <name>apiNote</name>
+                            <placement>a</placement>
+                            <head>API note:</head>
+                        </tag>
+                    </tags>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
so that Javadoc can be built correctly. we have a couple of these in the docs:

https://github.com/jakartaee/persistence/blob/823d5f94be0b4918f4926fad4f73db0fdea2c6df/api/src/main/java/jakarta/persistence/EntityHandler.java#L814

and Maven ends up complainig that it doesn't know how to render that.