### PR TITLE
Remove maven-scm-publish-plugin plugin trying to publish some GitHub pages

### DIFF
--- a/tck/docs/parent/pom.xml
+++ b/tck/docs/parent/pom.xml
@@ -191,26 +191,6 @@
                         </execution>
                     </executions>
                 </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-scm-publish-plugin</artifactId>
-                    <version>3.3.0</version>
-                    <executions>
-                        <execution>
-                            <id>deploy-site</id>
-                            <goals>
-                                <goal>publish-scm</goal>
-                            </goals>
-                            <phase>deploy</phase>
-                            <configuration>
-                                <scmBranch>gh-pages</scmBranch>
-                                <skipDeletedFiles>false</skipDeletedFiles>
-                                <checkinComment>Update site</checkinComment>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
         
@@ -268,17 +248,6 @@
                     <execution>
                         <id>copy-resources</id>
                         <phase>generate-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-scm-publish-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>deploy-site</id>
-                        <phase>deploy</phase>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
We don't have any GitHub pages for this repository, and if we decide we want to publish any docs as part of the TCK release we should probably do that as part of a CI release (and do not do that during SNAPSHOT deployments)