### PR TITLE
Switch the "default" branch to publish nightly javadoc pages to the website

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -15,7 +15,7 @@ name: Update web site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["master"]
+    branches: ["main"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
since we won't be pushing to "master" now...