### PR TITLE
demote joinTransaction() and isJoinedToTransaction() down to EM

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityHandler.java
+++ b/api/src/main/java/jakarta/persistence/EntityHandler.java
@@ -967,30 +967,6 @@ public sealed interface EntityHandler extends AutoCloseable
             String procedureName, String... resultSetMappings);
 
     /**
-     * Join the current active JTA transaction.
-     * <p>This method should be called on a JTA application-managed
-     * {@code EntityHandler} that was created outside the scope of
-     * the active transaction or on an {@code EntityHandler} of
-     * type {@link SynchronizationType#UNSYNCHRONIZED} to associate
-     * it with the current JTA transaction.
-     * @throws TransactionRequiredException if there is no active
-     *         transaction
-     * @since 1.0
-     */
-    void joinTransaction();
-
-    /**
-     * Determine whether the {@code EntityHandler} is joined to the
-     * current transaction. Returns false if the {@code EntityHandler}
-     * is not joined to the current transaction or if no
-     * transaction is active.
-     * @return True if the {@code EntityHandler} is joined to the
-     *         current transaction, or false otherwise
-     * @since 2.1
-     */
-    boolean isJoinedToTransaction();
-
-    /**
      * Return an object of the specified type to allow access to
      * a provider-specific API. If the provider implementation
      * of {@code EntityHandler} does not support the given type,

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -794,6 +794,30 @@ public non-sealed interface EntityManager extends EntityHandler {
     LockModeType getLockMode(Object entity);
 
     /**
+     * Join the current active JTA transaction.
+     * <p>This method should be called on a JTA application-managed
+     * {@code EntityManager} that was created outside the scope of
+     * the active transaction or on an {@code EntityManager} of
+     * type {@link SynchronizationType#UNSYNCHRONIZED} to associate
+     * it with the current JTA transaction.
+     * @throws TransactionRequiredException if there is no active
+     *         transaction
+     * @since 1.0
+     */
+    void joinTransaction();
+
+    /**
+     * Determine whether the {@code EntityManager} is joined to the
+     * current transaction. Returns false if the {@code EntityManager}
+     * is not joined to the current transaction or if no
+     * transaction is active.
+     * @return True if the {@code EntityManager} is joined to the
+     *         current transaction, or false otherwise
+     * @since 2.1
+     */
+    boolean isJoinedToTransaction();
+
+    /**
      * Return the underlying provider object for the
      * {@link EntityManager}, if available. The result of this
      * method is implementation-specific.


### PR DESCRIPTION
Turns out `joinTransaction()` and `isJoinedToTransaction()` don't make sense for an `EntityAgent`.

I'm just going to merge this one, since it was a simple conceptual misunderstanding on my part that led to me promoting these operations to `EntityHandler`.