### PR TITLE
@PersistenceModule

### DIFF
--- a/api/src/main/java/jakarta/persistence/PersistenceModule.java
+++ b/api/src/main/java/jakarta/persistence/PersistenceModule.java
@@ -31,7 +31,8 @@ import static jakarta.persistence.ValidationMode.AUTO;
 
 /**
  * Declares that the annotated module defines a persistence unit
- * and specifies static configuration for the persistence unit.
+ * with the same name as the module itself and specifies static
+ * configuration for the persistence unit.
  * <p>For example, the following annotation declares a persistence
  * unit named {@code org.example.library} with resouce-local
  * transaction management:
@@ -53,18 +54,17 @@ import static jakarta.persistence.ValidationMode.AUTO;
  * <p>
  * Configuration more specific to a given deployment of the unit
  * may be provided in a standard Java properties file located at
- * {@code META-INF/org.example.persistenceModule.properties},
- * where {@code org.example.persistenceModule} is the name of the
- * unit, as specified by the {@link #name} attribute. Properties
- * settings specified in this file override setting specified by
- * this annotation.
+ * for example, {@code META-INF/org.example.library.properties},
+ * where {@code org.example.library} is the name of the unit
+ * (the module name). Properties settings specified in this file
+ * override setting specified by this annotation.
  * <p>
  * This annotation is an alternative to declaring the persistence
  * unit by means of the {@code <persistence-unit>} element of the
  * venerable {@code META-INF/persistence.xml} file.
  * <p>
  * An entity manager factory may be created for the persistence
- * unit by passing the {@linkplain #name} of the unit to
+ * unit by passing the unit/module name to
  * {@link Persistence#createEntityManagerFactory(String)}.
  * @see Persistence#createEntityManagerFactory(String)
  * @see Persistence#createEntityManagerFactory(String,java.util.Map)
@@ -74,11 +74,6 @@ import static jakarta.persistence.ValidationMode.AUTO;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.MODULE)
 public @interface PersistenceModule {
-    /**
-     * The name of the persistence unit.
-     * <p>Defaults to the module name.
-     */
-    String name() default "";
 
     /**
      * The transaction type of the persistence unit.

--- a/api/src/main/java/jakarta/persistence/PersistenceModule.java
+++ b/api/src/main/java/jakarta/persistence/PersistenceModule.java
@@ -37,6 +37,12 @@ import static jakarta.persistence.ValidationMode.AUTO;
  * unit named {@code org.example.library} with resouce-local
  * transaction management:
  * {@snippet :
+ * import jakarta.persistence.PersistenceModule;
+ * import jakarta.persistence.PersistenceProperty;
+ * import static jakarta.persistence.TransactionType.RESOURCE_LOCAL;
+ * import static jakarta.persistence.PersistenceConfiguration.*;
+ * import static jakarta.persistence.PersistenceConfiguration.SchemaManagementAction.VALIDATE;
+ *
  * @PersistenceModule(
  *     transactionType = RESOURCE_LOCAL,
  *     classes = {Book.class, Author.class, Publisher.class},
@@ -45,8 +51,8 @@ import static jakarta.persistence.ValidationMode.AUTO;
  *     qualifiers = Library.class,
  *     schemaManagementDatabaseAction = VALIDATE,
  *     properties = {
- *         @PersistenceProperty(name="jakarta.persistence.jdbc.batchSize", value="20"),
- *         @PersistenceProperty(name="jakarta.persistence.jdbc.fetchSize", value="1000")
+ *         @PersistenceProperty(name = JDBC_BATCH_SIZE, value = "20"),
+ *         @PersistenceProperty(name = JDBC_FETCH_SIZE, value = "1000")
  *     }
  * )
  * module org.example.library { ... }

--- a/api/src/main/java/jakarta/persistence/PersistenceModule.java
+++ b/api/src/main/java/jakarta/persistence/PersistenceModule.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 4.0
+
+package jakarta.persistence;
+
+import jakarta.persistence.PersistenceConfiguration.SchemaManagementAction;
+import jakarta.persistence.spi.PersistenceProvider;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static jakarta.persistence.PersistenceConfiguration.SchemaManagementAction.NONE;
+import static jakarta.persistence.PersistenceUnitTransactionType.JTA;
+import static jakarta.persistence.SharedCacheMode.UNSPECIFIED;
+import static jakarta.persistence.ValidationMode.AUTO;
+
+/**
+ * Declares that the annotated module defines a persistence unit
+ * and specifies static configuration for the persistence unit.
+ * <p>For example, the following annotation declares a persistence
+ * unit named {@code org.example.library} with resouce-local
+ * transaction management:
+ * {@snippet :
+ * @PersistenceModule(
+ *     transactionType = RESOURCE_LOCAL,
+ *     classes = {Book.class, Author.class, Publisher.class},
+ *     excludeUnlistedClasses = true, // faster startup (no scanning)
+ *     nonJtaDatasource = "java:/comp/env/libraryData",
+ *     qualifiers = Library.class,
+ *     schemaManagementDatabaseAction = VALIDATE,
+ *     properties = {
+ *         @PersistenceProperty(name="jakarta.persistence.jdbc.batchSize", value="20"),
+ *         @PersistenceProperty(name="jakarta.persistence.jdbc.fetchSize", value="1000")
+ *     }
+ * )
+ * module org.example.library { ... }
+ * }
+ * <p>
+ * Configuration more specific to a given deployment of the unit
+ * may be provided in a standard Java properties file located at
+ * {@code META-INF/org.example.persistenceModule.properties},
+ * where {@code org.example.persistenceModule} is the name of the
+ * unit, as specified by the {@link #name} attribute. Properties
+ * settings specified in this file override setting specified by
+ * this annotation.
+ * <p>
+ * This annotation is an alternative to declaring the persistence
+ * unit by means of the {@code <persistence-unit>} element of the
+ * venerable {@code META-INF/persistence.xml} file.
+ * <p>
+ * An entity manager factory may be created for the persistence
+ * unit by passing the {@linkplain #name} of the unit to
+ * {@link Persistence#createEntityManagerFactory(String)}.
+ * @see Persistence#createEntityManagerFactory(String)
+ * @see Persistence#createEntityManagerFactory(String,java.util.Map)
+ * @see PersistenceConfiguration
+ * @since 4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.MODULE)
+public @interface PersistenceModule {
+    /**
+     * The name of the persistence unit.
+     * <p>Defaults to the module name.
+     */
+    String name() default "";
+
+    /**
+     * The transaction type of the persistence unit.
+     * <p>Defaults to
+     * {@link PersistenceUnitTransactionType#JTA JTA}
+     */
+    PersistenceUnitTransactionType transactionType() default JTA;
+
+    /**
+     * An optional description of the persistence unit.
+     */
+    String description() default "";
+
+    /**
+     * The name of a class implementing
+     * {@link PersistenceProvider}.
+     */
+    String provider() default "";
+
+    /**
+     * The fully qualified class name of an annotation
+     * annotated {@code jakarta.inject.Scope} or
+     * {@code jakarta.enterprise.context.NormalScope}.
+     * This scope annotation may be used to determine
+     * the scope of an injected persistence context.
+     */
+    Class<? extends Annotation> scope() default Annotation.class;
+
+    /**
+     * The fully qualified class names of annotations
+     * annotated {@code jakarta.inject.Qualifier}.
+     * These qualifier annotations may be used to
+     * disambiguate an injected persistence unit.
+     */
+    Class<? extends Annotation>[] qualifiers() default {};
+
+    /**
+     * The JNDI name of a JTA {@code javax.sql.DataSource}.
+     */
+    String jtaDataSource() default "";
+
+    /**
+     * The JNDI name of a non-JTA {@code javax.sql.DataSource}.
+     */
+    String nonJtaDataSource() default "";
+
+    /**
+     * A list of URLs of jar files the persistence provider must
+     * examine and search for managed classes of the persistence
+     * unit. A URL might be a {@code file:} URL referring to a jar
+     * file or referring to a directory that contains an exploded
+     * jar file.
+     */
+    String[] jarFileUrls() default {};
+
+    /**
+     * A list of names of the mapping files the persistence
+     * provider must load to determine mappings for the entity
+     * classes. The mapping files must be in the standard XML
+     * mapping format, be uniquely named, and be resource-loadable
+     * from the application classpath.
+     */
+    String[] mappingFileNames() default {};
+
+    /**
+     * A list of managed classes. Each class is an {@link Entity},
+     * {@link Embeddable}, {@link MappedSuperclass}, or {@link Converter}.
+     */
+    String[] classes() default {};
+
+    /**
+     * Determines whether classes in the root of the persistence
+     * unit that have not been explicitly listed are included in
+     * the set of managed classes.
+     * <p>By default, they are included.
+     */
+    boolean excludeUnlistedClasses() default false;
+
+    /**
+     * The {@linkplain SharedCacheMode shared cache mode} of the
+     * persistence unit.
+     */
+    SharedCacheMode sharedCacheMode() default UNSPECIFIED;
+
+    /**
+     * The {@linkplain ValidationMode validation mode} of the
+     * persistence unit.
+     */
+    ValidationMode validationMode() default AUTO;
+
+//    /**
+//     * The {@linkplain FetchType default fetch type} for one-to-one
+//     * and many-to-one associations for this persistence unit.
+//     * <p>Defaults to {@link FetchType#LAZY} for a persistence unit
+//     * declared via this annotation.
+//     * @apiNote The default fetch type for a persistence unit
+//     * declared via this annotation is the opposite of the default
+//     * fetch type for a persistence unit declared in the
+//     * {@code META-INF/persistence.xml} file, reflecting that the
+//     * use of {@code fetch=LAZY} is strongly recommended for all
+//     * newly written code.
+//     */
+//    FetchType defaultFetchType() default LAZY;
+
+    /**
+     * The schema management action to be performed against the database.
+     */
+    SchemaManagementAction schemaManagementDatabaseAction() default NONE;
+
+    /**
+     * The schema management action to be performed by generated DDL scripts.
+     */
+    SchemaManagementAction schemaManagementScriptsAction() default NONE;
+
+    /**
+     * Standard and vendor-specific property settings.
+     * <p>These property settings may be overridden by supplying
+     * additional properties in a standard Java properties file
+     * located at {@code META-INF/unitName.properties}.
+     */
+    PersistenceProperty[] properties() default {};
+}

--- a/api/src/main/java/jakarta/persistence/spi/PersistenceUnitInfo.java
+++ b/api/src/main/java/jakarta/persistence/spi/PersistenceUnitInfo.java
@@ -110,7 +110,7 @@ public interface PersistenceUnitInfo {
      * Returns the list of the names of the mapping files that the
      * persistence provider must load to determine the mappings for
      * the entity classes. The mapping files must be in the standard
-     * XML mapping format, be uniquely named and be resource-loadable
+     * XML mapping format, be uniquely named, and be resource-loadable
      * from the application classpath.  Each mapping file name
      * corresponds to a {@code mapping-file} element in the
      * {@code persistence.xml} file.
@@ -126,9 +126,10 @@ public interface PersistenceUnitInfo {
      * for managed classes of the persistence unit. Each URL
      * corresponds to a {@code jar-file} element in the
      * {@code persistence.xml} file. A URL will either be a
-     * file: URL referring to a jar file or referring to a directory
-     * that contains an exploded jar file, or some other URL from
-     * which an InputStream in jar format can be obtained.
+     * {@code file:} URL referring to a jar file or referring to a
+     * directory that contains an exploded jar file, or some other
+     * URL from which an {@code InputStream} in jar format can be
+     * obtained.
      * @return a list of URL objects referring to jar files or
      * directories 
      */

--- a/spec/src/main/asciidoc/ch08-entity-packaging.adoc
+++ b/spec/src/main/asciidoc/ch08-entity-packaging.adoc
@@ -63,7 +63,10 @@ be unique within a given EJB-JAR file, within a given WAR file, within a
 given application client JAR, or within an EAR. See <<a12459>>.
 
 The `persistence.xml` file may be used to define more than one persistence
-unit within the same scope.
+unit within the same scope. Alternatively, if the jar file contains a Java
+module, `PersistenceModule` annotation described in <<persistence-module>>
+may be used to define exactly one persistence unit which is identified with
+the module itself.
 
 All persistence classes defined at the level of the Jakarta EE EAR must be
 accessible to other Jakarta EE components in the application—that is, to
@@ -77,6 +80,21 @@ described in the following sections can be used. To ensure the portability
 of a Java SE application, it is necessary to explicitly list the managed
 persistence classes included in the persistence unit using the `class`
 element of the `persistence.xml` file. See <<a12305>>.
+
+==== Persistence Properties Files
+
+A persistence unit may have a Java properties file located in the `META-INF`
+directory. The name of the properties file is obtained by concatenating the
+name of the persistence unit with the standard extension `.properties`. For
+example, if the name of the persistence unit is `org.example`, the properties
+file is `META-INF/org.example.properties`.
+
+Property settings supplied in the properties file belonging to a persistence
+unit augment and override any properties specified in `persistence.xml` or
+by the `PersistenceModule` annotation. Any of the properties defined in
+<<a13443>> may be included in the properties file belonging to a persistence
+unit, and may override information specified in `persistence.xml` or via
+annotations members of `PersistenceModule`.
 
 ==== persistence.xml file [[a12237]]
 

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -15,10 +15,8 @@ These annotations and types are in the package `jakarta.persistence`.
 === PersistenceModule [[persistence-module]]
 
 The `PersistenceModule` annotation declares a persistence unit identified
-with the annotated `module`.
-
-The `name` annotation element specifies the name of the persistence unit,
-and defaults to the name of the module.
+with the annotated `module`. The name of the persistence unit is identical
+to the name of the module.
 
 The remaining annotation elements are interpreted identically to the
 similarly named XML elements of the `persistence.xml` file, as defined in
@@ -29,7 +27,6 @@ similarly named XML elements of the `persistence.xml` file, as defined in
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.MODULE)
 public @interface PersistenceModule {
-    String name() default "";
     PersistenceUnitTransactionType transactionType() default JTA;
     String description() default "";
     String provider() default "";

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -12,6 +12,44 @@ The XML schema defined in chapter
 
 These annotations and types are in the package `jakarta.persistence`.
 
+=== PersistenceModule [[persistence-module]]
+
+The `PersistenceModule` annotation declares a persistence unit identified
+with the annotated `module`.
+
+The `name` annotation element specifies the name of the persistence unit,
+and defaults to the name of the module.
+
+The remaining annotation elements are interpreted identically to the
+similarly named XML elements of the `persistence.xml` file, as defined in
+<<a12237>>.
+
+[source,java]
+----
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.MODULE)
+public @interface PersistenceModule {
+    String name() default "";
+    PersistenceUnitTransactionType transactionType() default JTA;
+    String description() default "";
+    String provider() default "";
+    Class<? extends Annotation> scope() default Annotation.class;
+    Class<? extends Annotation>[] qualifiers() default {};
+    String jtaDataSource() default "";
+    String nonJtaDataSource() default "";
+    String[] jarFileUrls() default {};
+    String[] mappingFileNames() default {};
+    String[] classes() default {};
+    boolean excludeUnlistedClasses() default false;
+    SharedCacheMode sharedCacheMode() default UNSPECIFIED;
+    ValidationMode validationMode() default AUTO;
+//    FetchType defaultFetchType() default LAZY;
+    SchemaManagementAction schemaManagementDatabaseAction() default NONE;
+    SchemaManagementAction schemaManagementScriptsAction() default NONE;
+    PersistenceProperty[] properties() default {};
+}
+----
+
 === Entity [[entity-annotation]]
 
 The `Entity` annotation specifies that the annotated class is an entity.


### PR DESCRIPTION
This change introduces:

- a way to declare a Java `module` as defining a persistence unit (or "persistence archive" in language we were using early on), that is, a package of entities and related code, along with XML mapping files, and 
- an annotation for specifying "static" configuration information which does not vary with the deployment, as an alternative to `persistence.xml`, and
- a way to segregate deployment-specific information into a separate `.properties` file.

See https://github.com/jakartaee/persistence/issues/701#issuecomment-3683334139.

_NOTE: This proposal is on ice until I can get feedback from someone else who is prepared to spend time thinking carefully about what a "persistence unit" or "persistence module" is going to mean in the future. Since I have not been able to gather such feedback yet, this feature is not currently planned for JPA 4._