### PR TITLE
introduce QueryOption

### DIFF
--- a/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheRetrieveMode.java
@@ -36,7 +36,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum CacheRetrieveMode implements FindOption {
+public enum CacheRetrieveMode implements FindOption, QueryOption {
 
     /**
      * Specifies that data may be read from the second-level cache

--- a/api/src/main/java/jakarta/persistence/CacheStoreMode.java
+++ b/api/src/main/java/jakarta/persistence/CacheStoreMode.java
@@ -38,7 +38,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum CacheStoreMode implements FindOption, RefreshOption {
+public enum CacheStoreMode implements FindOption, RefreshOption, QueryOption {
 
     /**
      * Specifies that entity data may be inserted into the

--- a/api/src/main/java/jakarta/persistence/LockModeType.java
+++ b/api/src/main/java/jakarta/persistence/LockModeType.java
@@ -83,7 +83,7 @@ package jakarta.persistence;
  * @since 1.0
  *
  */
-public enum LockModeType implements FindOption, RefreshOption {
+public enum LockModeType implements FindOption, RefreshOption, QueryOption {
     /**
      * Synonymous with {@link #OPTIMISTIC}.
      * <p>

--- a/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
+++ b/api/src/main/java/jakarta/persistence/PessimisticLockScope.java
@@ -37,7 +37,7 @@ package jakarta.persistence;
  *
  * @since 2.0
  */
-public enum PessimisticLockScope implements FindOption, RefreshOption, LockOption {
+public enum PessimisticLockScope implements FindOption, RefreshOption, LockOption, QueryOption {
 
     /**
      * <p>The persistence provider must lock the row or rows of the

--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -696,6 +696,15 @@ public interface Query {
     Integer getTimeout();
 
     /**
+     * Set a query option. Usually used for provider-specific
+     * options.
+     * @param option Any instance of {@link QueryOption}
+     * @return the same query instance
+     * @since 4.0
+     */
+    Query setOption(QueryOption option);
+
+    /**
      * Return an object of the specified type to allow access to 
      * a provider-specific API. If the provider implementation of
      * {@code Query} does not support the given type, the

--- a/api/src/main/java/jakarta/persistence/QueryOption.java
+++ b/api/src/main/java/jakarta/persistence/QueryOption.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+// Contributors:
+//     Gavin King      - 4.0
+
+
+package jakarta.persistence;
+
+/**
+ * An option influencing {@linkplain Query query execution}.
+ * Built-in options control {@linkplain LockModeType locking},
+ * {@linkplain CacheRetrieveMode cache interaction}, and
+ * {@linkplain Timeout timeouts}.
+ *
+ * <p>This interface may be implemented by custom provider-specific
+ * options which extend the options defined by the specification.
+ *
+ * @see LockModeType
+ * @see PessimisticLockScope
+ * @see CacheRetrieveMode
+ * @see CacheStoreMode
+ * @see Timeout
+ *
+ * @see Query#setOption(QueryOption)
+ * @see TypedQueryReference#getOptions()
+ *
+ * @since 4.0
+ */
+public interface QueryOption {
+}

--- a/api/src/main/java/jakarta/persistence/Timeout.java
+++ b/api/src/main/java/jakarta/persistence/Timeout.java
@@ -22,7 +22,7 @@ package jakarta.persistence;
  *
  * @since 3.2
  */
-public class Timeout implements FindOption, RefreshOption, LockOption {
+public class Timeout implements FindOption, RefreshOption, LockOption, QueryOption {
     private final int milliseconds;
 
     private Timeout(int milliseconds) {

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -415,4 +415,13 @@ public interface TypedQuery<X> extends Query {
      * @since 3.2
      */
     TypedQuery<X> setTimeout(Integer timeout);
+
+    /**
+     * Set a query option. Usually used for provider-specific
+     * options.
+     * @param option Any instance of {@link QueryOption}
+     * @return the same query instance
+     * @since 4.0
+     */
+    TypedQuery<X> setOption(QueryOption option);
 }

--- a/api/src/main/java/jakarta/persistence/TypedQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/TypedQueryReference.java
@@ -108,7 +108,7 @@ public interface TypedQueryReference<R> {
     Map<String,Object> getHints();
 
     /**
-     * Any {@linkplain FindOption options} controlling
+     * Any {@linkplain QueryOption options} controlling
      * execution of the query.
      * <p>
      * Any mutation of the returned list results in an
@@ -116,7 +116,7 @@ public interface TypedQueryReference<R> {
      *
      * @since 4.0
      */
-    List<FindOption> getOptions();
+    List<QueryOption> getOptions();
 
     /**
      * The types of the supplied

--- a/api/src/main/java/jakarta/persistence/query/StaticQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/query/StaticQueryReference.java
@@ -15,7 +15,7 @@
 
 package jakarta.persistence.query;
 
-import jakarta.persistence.FindOption;
+import jakarta.persistence.QueryOption;
 import jakarta.persistence.TypedQueryReference;
 
 import java.util.List;
@@ -42,7 +42,7 @@ public class StaticQueryReference<R>
     private final List<Class<?>> parameterTypes;
     private final List<String> parameterNames;
     private final List<Object> arguments;
-    private final List<FindOption> options;
+    private final List<QueryOption> options;
     private final Map<String, Object> hints;
 
     public StaticQueryReference(
@@ -54,7 +54,7 @@ public class StaticQueryReference<R>
             List<String> parameterNames,
             List<Object> arguments,
             Map<String, Object> hints,
-            FindOption... options) {
+            QueryOption... options) {
         this.name = queryName;
         this.annotatedClass = annotatedClass;
         this.annotatedMemberName = annotatedMemberName;
@@ -82,7 +82,7 @@ public class StaticQueryReference<R>
     }
 
     @Override
-    public List<FindOption> getOptions() {
+    public List<QueryOption> getOptions() {
         return options;
     }
 

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/QueryImpl.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/QueryImpl.java
@@ -29,6 +29,7 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
 import jakarta.persistence.PessimisticLockScope;
+import jakarta.persistence.QueryOption;
 import jakarta.persistence.TemporalType;
 import jakarta.persistence.TypedQuery;
 
@@ -206,6 +207,11 @@ public class QueryImpl<X> implements TypedQuery<X> {
 
 	@Override
 	public TypedQuery<X> setTimeout(Integer timeout) {
+		return null;
+	}
+
+	@Override
+	public TypedQuery<X> setOption(QueryOption option) {
 		return null;
 	}
 


### PR DESCRIPTION
See #866.

The value of this over just having `FindOption` is a bit marginal. But it's conceptually cleaner, and we might very well appreciate having it in the future.