### PR TITLE
Remove declaration of EntityHandler as sealed

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityAgent.java
+++ b/api/src/main/java/jakarta/persistence/EntityAgent.java
@@ -56,7 +56,7 @@ import java.util.List;
  *
  * @see EntityManager
  */
-public non-sealed interface EntityAgent extends EntityHandler {
+public interface EntityAgent extends EntityHandler {
 
     /**
      * Insert a record.

--- a/api/src/main/java/jakarta/persistence/EntityHandler.java
+++ b/api/src/main/java/jakarta/persistence/EntityHandler.java
@@ -78,8 +78,7 @@ import java.util.Map;
  *
  * @since 4.0
  */
-public sealed interface EntityHandler extends AutoCloseable
-        permits EntityManager, EntityAgent {
+public interface EntityHandler extends AutoCloseable {
 
     /**
      * Retrieve an entity representing the record with the

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -201,7 +201,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
  * 
  * @since 1.0
  */
-public non-sealed interface EntityManager extends EntityHandler {
+public interface EntityManager extends EntityHandler {
 
     /**
      * Make a new entity instance managed and persistent, resulting in


### PR DESCRIPTION
Remove declaration of `EntityHandler` as sealed.  As defined, providers cannot properly define a common implementation.

For example, in Hibernate we have a contract named `SharedSessionContract` which is the base of both our `Session` (`EntityManager`) and `StatelessSession` (`EntityAgent`).  Naturally, this thing would implement `EntityHandler` and define common implementations of various `EntityHandler` methods.  However, that is not possible currently because `EntityHandler` is sealed and only permits `EntityMaager` and `EntityAgent` as implementors.

This PR removes the sealing of `EntityHandler`.