### PR TITLE
Remove declaration of ResultSetMapping as sealed

### DIFF
--- a/api/src/main/java/jakarta/persistence/sql/ResultSetMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/ResultSetMapping.java
@@ -66,10 +66,15 @@ import jakarta.persistence.metamodel.SingularAttribute;
  * @see jakarta.persistence.StoredProcedureQuery#getSingleResult(ResultSetMapping)
  * @see jakarta.persistence.StoredProcedureQuery#getSingleResultOrNull(ResultSetMapping)
  *
+ * @see CompoundMapping
+ * @see TupleMapping
+ * @see EntityMapping
+ * @see ConstructorMapping
+ * @see ColumnMapping
+ *
  * @since 4.0
  */
-public sealed interface ResultSetMapping<T>
-        permits CompoundMapping, TupleMapping, EntityMapping, ConstructorMapping, ColumnMapping {
+public interface ResultSetMapping<T> {
     /**
      * The result type of the mapping.
      */


### PR DESCRIPTION
Hibernate, and I am assuming other providers, have historical ways to define more rich ResultSet mappings.  

Because ResultSetMapping was introduced as sealed and all of its impls as records, it is impossible to model those richer models using this API; which is a shame imo.  Here is a PR to remove the seal and allow such usage.

A further step would be to make the impls NOT records.  This would allow even better implementation of this idea by implementors.  I held off on that for the time being until we had consensus on this idea in general.

https://github.com/jakartaee/persistence/issues/887