### PR TITLE
Include the version qualifier in the rendered spec file names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,23 @@
                             <rootLocationProperty>rootProject.directory</rootLocationProperty>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>project-qualifier-with-dash</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <configuration>
+                            <name>parsed-version.project.formatted.qualifier</name>
+                            <!--
+                                We add a dash in the value, if the qualifier is absent
+                                then the regex will replace that single `-` with an empty string.
+                             -->
+                            <value>-${parsed-version.jakarta.persistence.qualifier}</value>
+                            <regex>^-$</regex>
+                            <replacement></replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -33,7 +33,7 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
-        <spec.version.short>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}</spec.version.short>
+        <spec.version.short>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}${parsed-version.project.formatted.qualifier}</spec.version.short>
         <spec.name>jakarta-${project.artifactId}-${spec.version.short}</spec.name>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status>DRAFT</status>


### PR DESCRIPTION
tested with snapshot/m1/(final i.e. 4.0.0) and all seem to work ok.