### PR TITLE
mention PessimisticLockScope in the jdoc for lock()

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -530,7 +530,10 @@ public interface EntityManager extends EntityHandler {
     /**
      * Lock an entity instance belonging to the persistence context,
      * obtaining the specified {@linkplain LockModeType lock mode},
-     * using the specified {@linkplain LockOption options}.
+     * using the specified {@linkplain LockOption options}. If the
+     * given options include a {@link PessimisticLockScope}, the
+     * specified scope determines whether a pessimistic lock is
+     * applied to associated collections and relationships.
      * <p>If a pessimistic lock mode type is specified and the entity
      * contains a version attribute, the persistence provider must
      * also perform optimistic version checks when obtaining the

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -620,7 +620,7 @@ public interface TypedQuery<X> extends Query {
      TypedQuery<X> setLockMode(LockModeType lockMode);
 
     /**
-     * Set the {@link PessimisticLockScope pessimistic lock scope}
+     * Set the {@linkplain PessimisticLockScope pessimistic lock scope}
      * to use when the query is executed if a pessimistic lock mode
      * is specified via {@link #setLockMode}.
      * If the query is executed without a pessimistic lock mode,


### PR DESCRIPTION
The javadoc for `EntityManager.lock()` should at least mention the possibility of passing a `PessimisticLockScope`.