### PR TITLE
Add docinfo to include canonical link/keywords/description

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -33,6 +33,7 @@
         <site.output.dir>${project.build.directory}/staging</site.output.dir>
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
+        <spec.version.family>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}</spec.version.family>
         <spec.version.short>${parsed-version.jakarta.persistence.majorVersion}.${parsed-version.jakarta.persistence.minorVersion}${parsed-version.project.formatted.qualifier}</spec.version.short>
         <spec.name>jakarta-${project.artifactId}-${spec.version.short}</spec.name>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
@@ -74,7 +75,6 @@
                                 <sectanchors>true</sectanchors>
                                 <idprefix />
                                 <idseparator>-</idseparator>
-                                <docinfo1>true</docinfo1>
                             </attributes>
                         </configuration>
                     </execution>
@@ -110,8 +110,10 @@
                     <sourceDocumentName>jakarta.persistence-spec.adoc</sourceDocumentName>
                     <attributes>
                         <revnumber>${spec.version.short}</revnumber>
+                        <versionFamily>${spec.version.family}</versionFamily>
                         <revremark>${status}</revremark>
                         <revdate>${revisiondate}</revdate>
+                        <docinfodir>${project.basedir}/src/docinfo</docinfodir>
                     </attributes>
                 </configuration>
 

--- a/spec/src/docinfo/jakarta.persistence-spec-docinfo.html
+++ b/spec/src/docinfo/jakarta.persistence-spec-docinfo.html
@@ -1,0 +1,3 @@
+<meta name="description" content="Jakarta Persistence: the standard for management of persistence and object/relational mapping in Java applications - Specification" />
+<meta name="keywords" content="jakarta persistence, persistence, orm, database" />
+<link rel="canonical" href="https://jakarta.ee/specifications/persistence/{versionFamily}/jakarta-persistence-spec-{revnumber}" />

--- a/spec/src/main/asciidoc/jakarta.persistence-spec.adoc
+++ b/spec/src/main/asciidoc/jakarta.persistence-spec.adoc
@@ -8,6 +8,7 @@
 :email: https://dev.eclipse.org/mailman/listinfo/jpa-dev
 :version-label!:
 :doctype: book
+:docinfo: shared,private
 :license: Eclipse Foundation Specification License v1.1
 :source-highlighter: coderay
 :toc: left


### PR DESCRIPTION
I remembered that I had to do this for the validation spec.. so here's a patch for persistence as well.
(If you have a better description/keywords -- let me know 🙂)