### PR TITLE
Avoid depending on the java.logging module

### DIFF
--- a/api/src/main/java/jakarta/persistence/spi/PersistenceProviderResolverHolder.java
+++ b/api/src/main/java/jakarta/persistence/spi/PersistenceProviderResolverHolder.java
@@ -26,8 +26,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 
 
 /**
@@ -113,11 +113,11 @@ public class PersistenceProviderResolverHolder {
                             PersistenceProvider pp = ipp.next();
                             loadedProviders.add(pp);
                         } catch (ServiceConfigurationError sce) {
-                            log(Level.FINEST, sce.toString());
+                            log(Level.TRACE, sce.toString());
                         }
                     }
                 } catch (ServiceConfigurationError sce) {
-                    log(Level.FINEST, sce.toString());
+                    log(Level.TRACE, sce.toString());
                 }
 
                 // If none are found we'll log the provider names for diagnostic
@@ -150,7 +150,7 @@ public class PersistenceProviderResolverHolder {
 
         private void log(Level level, String message) {
             if (this.logger == null) {
-                this.logger = Logger.getLogger(LOGGER_SUBSYSTEM);
+                this.logger = System.getLogger(LOGGER_SUBSYSTEM);
             }
             this.logger.log(level, LOGGER_SUBSYSTEM + "::" + message);
         }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -17,7 +17,6 @@
  */
 module jakarta.persistence {
 
-    requires java.logging;
     requires transitive java.sql;
 
     exports jakarta.persistence;


### PR DESCRIPTION
There's a single class in the JPA API which is producing some diagnostic logging, and this causes the module to require the 'java.logging' module.

Yet many runtimes will be plugging in a different logging system; [JEP 264](https://openjdk.org/jeps/264) was introduced in Java 9 and seems perfect for this case: it allows libraries to rely on a very minimal logging system which will delegate to the logging system chosen by the runtime.

By default it delegates to `java.util.logging` IFF the 'java.logging' module is present - so this should have no impact on people who want to use `java.util.logging`.  The upside of merging this is that it would allow minimalist systems to avoid needing this module, as in many platforms we use different logger implementations. 