### PR TITLE
fix incorrect/inconsistent naming of a method

### DIFF
--- a/api/src/main/java/jakarta/persistence/PersistenceConfiguration.java
+++ b/api/src/main/java/jakarta/persistence/PersistenceConfiguration.java
@@ -374,7 +374,7 @@ public class PersistenceConfiguration
      * @see #SCHEMAGEN_SCRIPTS_ACTION
      * @since 4.0
      */
-    public SchemaManagementAction getSchemaManagementScriptsAction() {
+    public SchemaManagementAction schemaManagementScriptsAction() {
         return schemaManagementScriptsAction;
     }
 


### PR DESCRIPTION
I made a tiny mistake.