### PR TITLE
disallow mutation of record types by clients

### DIFF
--- a/api/src/main/java/jakarta/persistence/sql/CompoundMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/CompoundMapping.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 public record CompoundMapping(MappingElement<?>[] elements)
         implements ResultSetMapping<Object[]> {
 
-    public CompoundMapping {
+    public CompoundMapping(MappingElement<?>[] elements) {
         requireNonNull(elements, "elements are required");
         if (elements.length == 0) {
             throw new IllegalArgumentException("at least one element is required");
@@ -39,6 +39,7 @@ public record CompoundMapping(MappingElement<?>[] elements)
         for (var element : elements) {
             requireNonNull(element, "element is required");
         }
+        this.elements = elements.clone();
     }
 
     @Override

--- a/api/src/main/java/jakarta/persistence/sql/ConstructorMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/ConstructorMapping.java
@@ -33,7 +33,7 @@ import static java.util.Objects.requireNonNull;
 public record ConstructorMapping<T>(Class<T> targetClass, MappingElement<?>[] arguments)
         implements MappingElement<T>, ResultSetMapping<T> {
 
-    public ConstructorMapping {
+    public ConstructorMapping(Class<T> targetClass, MappingElement<?>[] arguments) {
         requireNonNull(targetClass, "targetClass is required");
         requireNonNull(arguments, "arguments are required");
         if (arguments.length == 0) {
@@ -42,6 +42,8 @@ public record ConstructorMapping<T>(Class<T> targetClass, MappingElement<?>[] ar
         for (var element : arguments) {
             requireNonNull(element, "argument is required");
         }
+        this.targetClass = targetClass;
+        this.arguments = arguments.clone();
     }
 
     @Override

--- a/api/src/main/java/jakarta/persistence/sql/EmbeddedMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/EmbeddedMapping.java
@@ -37,7 +37,7 @@ public record EmbeddedMapping<C,T>
         (Class<C> container, Class<T> embeddableClass, String name, MemberMapping<?>[] fields)
         implements MemberMapping<C> {
 
-    public EmbeddedMapping {
+    public EmbeddedMapping(Class<C> container, Class<T> embeddableClass, String name, MemberMapping<?>[] fields) {
         requireNonNull(container, "container is required");
         requireNonNull(embeddableClass, "embeddableClass is required");
         requireNonNull(name, "name is required");
@@ -45,6 +45,10 @@ public record EmbeddedMapping<C,T>
         for (var field : fields) {
             requireNonNull(field, "field is required");
         }
+        this.container = container;
+        this.embeddableClass = embeddableClass;
+        this.name = name;
+        this.fields = fields.clone();
     }
 
     @Override

--- a/api/src/main/java/jakarta/persistence/sql/EntityMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/EntityMapping.java
@@ -42,7 +42,7 @@ public record EntityMapping<T>
         (Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<?>[] fields)
         implements MappingElement<T>, ResultSetMapping<T> {
 
-    public EntityMapping {
+    public EntityMapping(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<?>[] fields) {
         requireNonNull(entityClass, "entityClass is required");
         requireNonNull(lockMode, "lockMode is required");
         if (discriminatorColumn != null && discriminatorColumn.isBlank()) {
@@ -52,6 +52,10 @@ public record EntityMapping<T>
         for (var field : fields) {
             requireNonNull(field, "field is required");
         }
+        this.entityClass = entityClass;
+        this.lockMode = lockMode;
+        this.discriminatorColumn = discriminatorColumn;
+        this.fields = fields.clone();
     }
 
     @Override

--- a/api/src/main/java/jakarta/persistence/sql/TupleMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/TupleMapping.java
@@ -52,7 +52,7 @@ import static java.util.Objects.requireNonNull;
 public record TupleMapping(MappingElement<?>[] elements)
         implements ResultSetMapping<Tuple> {
 
-    public TupleMapping {
+    public TupleMapping(MappingElement<?>[] elements) {
         requireNonNull(elements, "elements are required");
         if (elements.length == 0) {
             throw new IllegalArgumentException("at least one element is required");
@@ -60,6 +60,7 @@ public record TupleMapping(MappingElement<?>[] elements)
         for (var element : elements) {
             requireNonNull(element, "element is required");
         }
+        this.elements = elements.clone();
     }
 
     @Override


### PR DESCRIPTION
We have some `record` types with array members. We should prevent mutation of the arrays by returning clones to the client.

@njr-11 @otaviojava do we need to do something similar in Jakarta Data?