### PR TITLE
correct handling of inheritance in EntityMapping constructor methods

### DIFF
--- a/api/src/main/java/jakarta/persistence/sql/EmbeddedMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/EmbeddedMapping.java
@@ -34,10 +34,10 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0
  */
 public record EmbeddedMapping<C,T>
-        (Class<C> container, Class<T> embeddableClass, String name, MemberMapping<?>[] fields)
+        (Class<? super C> container, Class<T> embeddableClass, String name, MemberMapping<T>[] fields)
         implements MemberMapping<C> {
 
-    public EmbeddedMapping(Class<C> container, Class<T> embeddableClass, String name, MemberMapping<?>[] fields) {
+    public EmbeddedMapping(Class<? super C> container, Class<T> embeddableClass, String name, MemberMapping<T>[] fields) {
         requireNonNull(container, "container is required");
         requireNonNull(embeddableClass, "embeddableClass is required");
         requireNonNull(name, "name is required");
@@ -52,7 +52,7 @@ public record EmbeddedMapping<C,T>
     }
 
     @Override
-    public MemberMapping<?>[] fields() {
+    public MemberMapping<T>[] fields() {
         return fields.clone();
     }
 
@@ -67,7 +67,7 @@ public record EmbeddedMapping<C,T>
      * @param <C> The container type
      */
     @SafeVarargs
-    public static <C,T> EmbeddedMapping<C,T> of(Class<C> container, Class<T> embeddableClass, String name, MemberMapping<T>... fields) {
+    public static <C,T> EmbeddedMapping<C,T> of(Class<? super C> container, Class<T> embeddableClass, String name, MemberMapping<T>... fields) {
         return new EmbeddedMapping<>(container, embeddableClass, name, fields);
     }
 
@@ -79,7 +79,7 @@ public record EmbeddedMapping<C,T>
      * @param <C> The container type
      */
     @SafeVarargs
-    public static <C,T> EmbeddedMapping<C,T> of(SingularAttribute<C,T> embedded, MemberMapping<T>... fields) {
+    public static <C,T> EmbeddedMapping<C,T> of(SingularAttribute<? super C,T> embedded, MemberMapping<T>... fields) {
         return new EmbeddedMapping<>(embedded.getDeclaringType().getJavaType(), embedded.getJavaType(), embedded.getName(), fields);
     }
 }

--- a/api/src/main/java/jakarta/persistence/sql/EntityMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/EntityMapping.java
@@ -17,8 +17,6 @@ package jakarta.persistence.sql;
 
 import jakarta.persistence.LockModeType;
 
-import java.util.Arrays;
-
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -32,6 +30,7 @@ import static java.util.Objects.requireNonNull;
  *        discriminator}; a {@code null} value indicates that
  *        there is no discriminator column.
  * @param fields Mappings for fields or properties of the entity
+ *               and of its entity subclasses
  * @param <T> The entity type
  *
  * @see jakarta.persistence.EntityResult
@@ -39,10 +38,10 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0
  */
 public record EntityMapping<T>
-        (Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<?>[] fields)
+        (Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<? extends T>[] fields)
         implements MappingElement<T>, ResultSetMapping<T> {
 
-    public EntityMapping(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<?>[] fields) {
+    public EntityMapping(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<? extends T>[] fields) {
         requireNonNull(entityClass, "entityClass is required");
         requireNonNull(lockMode, "lockMode is required");
         if (discriminatorColumn != null && discriminatorColumn.isBlank()) {
@@ -59,7 +58,7 @@ public record EntityMapping<T>
     }
 
     @Override
-    public MemberMapping<?>[] fields() {
+    public MemberMapping<? extends T>[] fields() {
         return fields.clone();
     }
 
@@ -93,15 +92,28 @@ public record EntityMapping<T>
     /**
      * Construct a new instance.
      * @param entityClass The entity class
+     * @param lockMode The lock mode acquired by the SQL query
+     * @param fields Mappings for fields or properties of the entity
+     * @param <T> The entity type
+     */
+    @SafeVarargs
+    public static <T> EntityMapping<T> of(Class<T> entityClass, LockModeType lockMode, MemberMapping<T>... fields) {
+        return new EntityMapping<>(entityClass, lockMode, null, fields);
+    }
+
+    /**
+     * Construct a new instance.
+     * @param entityClass The entity class
      * @param discriminatorColumn The name of the column holding the
      *        {@linkplain jakarta.persistence.DiscriminatorColumn
      *        discriminator}; a {@code null} value indicates that
      *        there is no discriminator column.
      * @param fields Mappings for fields or properties of the entity
+     *               and of its entity subclasses
      * @param <T> The entity type
      */
     @SafeVarargs
-    public static <T> EntityMapping<T> of(Class<T> entityClass, String discriminatorColumn, MemberMapping<T>... fields) {
+    public static <T> EntityMapping<T> of(Class<T> entityClass, String discriminatorColumn, MemberMapping<? extends T>... fields) {
         return new EntityMapping<>(entityClass, LockModeType.NONE, discriminatorColumn, fields);
     }
 
@@ -114,10 +126,11 @@ public record EntityMapping<T>
      *        discriminator}; a {@code null} value indicates that
      *        there is no discriminator column.
      * @param fields Mappings for fields or properties of the entity
+     *               and of its entity subclasses
      * @param <T> The entity type
      */
     @SafeVarargs
-    public static <T> EntityMapping<T> of(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<T>... fields) {
+    public static <T> EntityMapping<T> of(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<? extends T>... fields) {
         return new EntityMapping<>(entityClass, lockMode, discriminatorColumn, fields);
     }
 

--- a/api/src/main/java/jakarta/persistence/sql/FieldMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/FieldMapping.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
  * @since 4.0
  */
 public record FieldMapping<C,T>
-        (Class<C> container, Class<T> type, String name, String columnName)
+        (Class<? super C> container, Class<T> type, String name, String columnName)
         implements MemberMapping<C> {
 
     public FieldMapping {
@@ -54,7 +54,7 @@ public record FieldMapping<C,T>
      * @param <C> The type of the entity or embeddable type
      * @param <T> The type of the field
      */
-    public static <C,T> FieldMapping<C,T> of(Class<C> container, Class<T> type, String name, String columnName) {
+    public static <C,T> FieldMapping<C,T> of(Class<? super C> container, Class<T> type, String name, String columnName) {
         return new FieldMapping<>(container, type, name, columnName);
     }
 
@@ -65,7 +65,7 @@ public record FieldMapping<C,T>
      * @param <C> The type of the entity or embeddable type
      * @param <T> The type of the field
      */
-    public static <C,T> FieldMapping<C,T> of(SingularAttribute<C,T> attribute, String columnName) {
+    public static <C,T> FieldMapping<C,T> of(SingularAttribute<? super C,T> attribute, String columnName) {
         return new FieldMapping<>(attribute.getDeclaringType().getJavaType(), attribute.getJavaType(), attribute.getName(), columnName);
     }
 }

--- a/api/src/main/java/jakarta/persistence/sql/ResultSetMapping.java
+++ b/api/src/main/java/jakarta/persistence/sql/ResultSetMapping.java
@@ -146,14 +146,29 @@ public sealed interface ResultSetMapping<T>
      * Construct a mapping for an entity class.
      *
      * @param entityClass The Java class of the entity
-     * @param discriminatorColumn The name of the column holding the discriminator;
-     *        an empty string indicates that there is no discriminator column
+     * @param lockMode The lock mode acquired by SQL query
      * @param fields Mappings for fields or properties of the entity
      *
      * @see jakarta.persistence.EntityResult
      */
     @SafeVarargs
-    static <T> EntityMapping<T> entity(Class<T> entityClass, String discriminatorColumn, MemberMapping<T>... fields) {
+    static <T> EntityMapping<T> entity(Class<T> entityClass, LockModeType lockMode, MemberMapping<T>... fields) {
+        return EntityMapping.of(entityClass, lockMode, fields);
+    }
+
+    /**
+     * Construct a mapping for an entity class.
+     *
+     * @param entityClass The Java class of the entity
+     * @param discriminatorColumn The name of the column holding the discriminator;
+     *        an empty string indicates that there is no discriminator column
+     * @param fields Mappings for fields or properties of the entity
+     *               and of its entity subclasses
+     *
+     * @see jakarta.persistence.EntityResult
+     */
+    @SafeVarargs
+    static <T> EntityMapping<T> entity(Class<T> entityClass, String discriminatorColumn, MemberMapping<? extends T>... fields) {
         return EntityMapping.of(entityClass, discriminatorColumn, fields);
     }
 
@@ -165,11 +180,12 @@ public sealed interface ResultSetMapping<T>
      * @param discriminatorColumn The name of the column holding the discriminator;
      *        an empty string indicates that there is no discriminator column
      * @param fields Mappings for fields or properties of the entity
+     *               and of its entity subclasses
      *
      * @see jakarta.persistence.EntityResult
      */
     @SafeVarargs
-    static <T> EntityMapping<T> entity(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<T>... fields) {
+    static <T> EntityMapping<T> entity(Class<T> entityClass, LockModeType lockMode, String discriminatorColumn, MemberMapping<? extends T>... fields) {
         return EntityMapping.of(entityClass, lockMode, discriminatorColumn, fields);
     }
 
@@ -182,7 +198,7 @@ public sealed interface ResultSetMapping<T>
      * @param fields Mappings for fields or properties of the entity
      */
     @SafeVarargs
-    static <C,T> EmbeddedMapping<C,T> embedded(Class<C> container, Class<T> embeddableClass, String name, MemberMapping<T>... fields) {
+    static <C,T> EmbeddedMapping<C,T> embedded(Class<? super C> container, Class<T> embeddableClass, String name, MemberMapping<T>... fields) {
         return EmbeddedMapping.of(container, embeddableClass, name, fields);
     }
 
@@ -193,7 +209,7 @@ public sealed interface ResultSetMapping<T>
      * @param fields Mappings for fields or properties of the entity
      */
     @SafeVarargs
-    static <C,T> EmbeddedMapping<C,T> embedded(SingularAttribute<C,T> embedded, MemberMapping<T>... fields) {
+    static <C,T> EmbeddedMapping<C,T> embedded(SingularAttribute<? super C,T> embedded, MemberMapping<T>... fields) {
         return EmbeddedMapping.of(embedded, fields);
     }
 
@@ -207,7 +223,7 @@ public sealed interface ResultSetMapping<T>
      *
      * @see jakarta.persistence.FieldResult
      */
-    static <C,T> FieldMapping<C,T> field(Class<C> container, Class<T> type, String name, String columnName) {
+    static <C,T> FieldMapping<C,T> field(Class<? super C> container, Class<T> type, String name, String columnName) {
         return FieldMapping.of(container, type, name, columnName);
     }
 
@@ -219,7 +235,7 @@ public sealed interface ResultSetMapping<T>
      *
      * @see jakarta.persistence.FieldResult
      */
-    static <C,T> FieldMapping<C,T> field(SingularAttribute<C,T> attribute, String columnName) {
+    static <C,T> FieldMapping<C,T> field(SingularAttribute<? super C,T> attribute, String columnName) {
         return FieldMapping.of(attribute, columnName);
     }
 }


### PR DESCRIPTION
Entities in result set mappings can have:

1. attributes inheritance from a suprtype (this also applies to embeddables)
2. attributes declared by entity subtypes, which need mapping, because queries are polymorphic

This change allows that, without loss of typesafety in the `entity()` constructor method.