### PR TITLE
Use entityHandler instead of session in query javadoc examples

### DIFF
--- a/api/src/main/java/jakarta/persistence/Query.java
+++ b/api/src/main/java/jakarta/persistence/Query.java
@@ -479,7 +479,7 @@ public interface Query {
      * }
      * {@snippet :
      * var books =
-     *     session.createNativeQuery("select * from books where :limit is null or pub_date > :limit",
+     *     em.createNativeQuery("select * from books where :limit is null or pub_date > :limit",
      *                               Book.class)
      *         .setParameter("limit", optionalDateLimit, LocalDate.class)
      *         .getResultList();
@@ -603,7 +603,7 @@ public interface Query {
      * }
      * {@snippet :
      * var books =
-     *     session.createNativeQuery("select * from books where ?1 is null or pub_date > ?1",
+     *     em.createNativeQuery("select * from books where ?1 is null or pub_date > ?1",
      *                               Book.class)
      *         .setParameter(1, optionalDateLimit, LocalDate.class)
      *         .getResultList();

--- a/api/src/main/java/jakarta/persistence/TypedQuery.java
+++ b/api/src/main/java/jakarta/persistence/TypedQuery.java
@@ -368,7 +368,7 @@ public interface TypedQuery<X> extends Query {
      * the argument might be {@code null}.
      * {@snippet :
      * var books =
-     *     session.createNativeQuery("select * from books where :limit is null or pub_date > :limit",
+     *     em.createNativeQuery("select * from books where :limit is null or pub_date > :limit",
      *                               Book.class)
      *         .setParameter("limit", optionalDateLimit, LocalDate.class)
      *         .getResultList();
@@ -489,7 +489,7 @@ public interface TypedQuery<X> extends Query {
      * the argument might be {@code null}.
      * {@snippet :
      * var books =
-     *     session.createNativeQuery("select * from books where ?1 is null or pub_date > ?1",
+     *     em.createNativeQuery("select * from books where ?1 is null or pub_date > ?1",
      *                               Book.class)
      *         .setParameter(1, optionalDateLimit, LocalDate.class)
      *         .getResultList();


### PR DESCRIPTION
I noticed that a few examples were using `session`, while I like that 😃, I wondered whether we should stick to em/entityhandler and so on for these ?

feel free to just close it if you think it's fine as it currently is 🙂 