### PR TITLE
simpler result mappings for @StaticNativeQuery

### DIFF
--- a/api/src/main/java/jakarta/persistence/ColumnResult.java
+++ b/api/src/main/java/jakarta/persistence/ColumnResult.java
@@ -16,8 +16,11 @@
 
 package jakarta.persistence;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
+
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -72,6 +75,14 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * in the {@link jakarta.persistence.sql.ResultSetMapping ResultSetMapping}
  * returned by {@link EntityManagerFactory#getResultSetMappings(Class)}.
  *
+ * <p>This annotation may be placed directly on a method annotated
+ * {@link jakarta.persistence.query.StaticNativeQuery}.
+ * {@snippet :
+ * @StaticNativeQuery("SELECT count(*) AS title_count FROM books WHERE title LIKE :pattern")
+ * @ColumnResult(name="title_count")
+ * int countBooks(String pattern);
+ * }
+ *
  * @see SqlResultSetMapping
  * @see NamedNativeQuery
  * @see ConstructorResult
@@ -80,8 +91,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 1.0
  */
-@Target({}) 
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(ColumnResult.ColumnResults.class)
 public @interface ColumnResult { 
 
     /**
@@ -96,4 +108,13 @@ public @interface ColumnResult {
      * @since 2.1
      */
     Class<?> type() default void.class;
+
+    /**
+     * @since 4.0
+     */
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @interface ColumnResults {
+        ColumnResult[] value();
+    }
 }

--- a/api/src/main/java/jakarta/persistence/ConstructorResult.java
+++ b/api/src/main/java/jakarta/persistence/ConstructorResult.java
@@ -17,8 +17,12 @@
 
 package jakarta.persistence;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
+
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -78,6 +82,18 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * in the {@link jakarta.persistence.sql.ResultSetMapping ResultSetMapping}
  * returned by {@link EntityManagerFactory#getResultSetMappings(Class)}.
  *
+ * <p>This annotation may be placed directly on a method annotated
+ * {@link jakarta.persistence.query.StaticNativeQuery}.
+ * {@snippet :
+ * @StaticNativeQuery("SELECT pub_id, count(*) AS book_count FROM books GROUP BY pub_id")
+ * @ConstructorResult(
+ *     targetClass = PublisherBookCount.class,
+ *     columns = {@ColumnResult("pub_id"),
+ *                @ColumnResult("book_count")}
+ * )
+ * List<PublisherBookCount> publisherBookCounts(String pattern);
+ * }
+ *
  * @see SqlResultSetMapping
  * @see NamedNativeQuery
  * @see ColumnResult
@@ -86,8 +102,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 2.1
  */
-@Target({}) 
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(ConstructorResult.ConstructorResults.class)
 public @interface ConstructorResult { 
 
     /**
@@ -120,4 +137,13 @@ public @interface ConstructorResult {
      * @since 4.0
      */
     EntityResult[] entities() default {};
+
+    /**
+     * @since 4.0
+     */
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @interface ConstructorResults {
+        ConstructorResult[] value();
+    }
 }

--- a/api/src/main/java/jakarta/persistence/ConstructorResult.java
+++ b/api/src/main/java/jakarta/persistence/ConstructorResult.java
@@ -17,7 +17,6 @@
 
 package jakarta.persistence;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
@@ -120,7 +119,7 @@ public @interface ConstructorResult {
      * {@linkplain #targetClass target class}, in order.
      *
      * <p>Constructor parameters mapping directly to column
-     * results must occur after parameters mapping to entities.
+     * results must occur before parameters mapping to entities.
      */
     ColumnResult[] columns() default {};
 

--- a/api/src/main/java/jakarta/persistence/EntityResult.java
+++ b/api/src/main/java/jakarta/persistence/EntityResult.java
@@ -17,8 +17,11 @@
 
 package jakarta.persistence;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Target;
 import java.lang.annotation.Retention;
+
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -71,6 +74,22 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * in the {@link jakarta.persistence.sql.ResultSetMapping ResultSetMapping}
  * returned by {@link EntityManagerFactory#getResultSetMappings(Class)}.
  *
+ * <p>This annotation may be placed directly on a method annotated
+ * {@link jakarta.persistence.query.StaticNativeQuery}.
+ * {@snippet :
+ * @StaticNativeQuery("SELECT * FROM orders WHERE order_total > ?")
+ * @EntityResult(
+ *     entityClass = Order.class,
+ *     fields = {@FieldResult(name = Order_.ID, column = "order_id"),
+ *               @FieldResult(name = Order_.TOTAL, column = "order_total"),
+ *               @FieldResult(name = Order_.ITEM, column = "order_item")}
+ * )
+ * List<Order> largeOrders(int threshold) {
+ *     return entityManager.createQuery(Shop_.largeOrders(threshold))
+ *             .getResultList();
+ * }
+ * }
+ *
  * @see SqlResultSetMapping
  * @see NamedNativeQuery
  *
@@ -78,8 +97,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * @since 1.0
  */
-@Target({}) 
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(EntityResult.EntityResults.class)
 public @interface EntityResult {
 
     /**
@@ -106,4 +126,13 @@ public @interface EntityResult {
      * is no discriminator column.
      */
     String discriminatorColumn() default "";
+
+    /**
+     * @since 4.0
+     */
+    @Target(METHOD)
+    @Retention(RUNTIME)
+    @interface EntityResults {
+        EntityResult[] value();
+    }
 }

--- a/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
+++ b/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
@@ -38,11 +38,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * each row of the mapped query result set is represented as an instance of
  * {@code Object[]} whose elements are, in order:
  * <ol>
- * <li>any entity results, in the order in which they are declared by the
+ * <li>entity results, in the order in which they are declared by the
  *     {@link #entities} element;
- * <li>any constructor results, in the order declared by the {@link #classes}
+ * <li>constructor results, in the order declared by the {@link #classes}
  *     element; and then
- * <li>any scalar results, in the order declared by the {@link #columns}
+ * <li>scalar results, in the order declared by the {@link #columns}
  *     element.
  * </ol>
  *

--- a/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
+++ b/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
@@ -34,6 +34,18 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Java class constructors}. Every SQL result set mapping has a {@link #name}.
  * SQL result set mapping names must be unique within a persistence unit.
  *
+ * <p>When a SQL result set mapping specifies more than one result mapping,
+ * each row of the mapped query result set is represented as an instance of
+ * {@code Object[]} whose elements are, in order:
+ * <ol>
+ * <li>any entity results, in the order in which they are declared by the
+ *     {@link #entities} element;
+ * <li>any constructor results, in the order declared by the {@link #classes}
+ *     element; and then
+ * <li>any scalar results, in the order declared by the {@link #columns}
+ *     element.
+ * </ol>
+ *
  * <p>In this example, a named mapping is declared by annotating an entity
  * class:
  * {@snippet :
@@ -82,7 +94,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * ResultSetMapping<Order> mapping =
  *         entityManager.getResultSetMappings(Order.class)
  *              .get(Order_.MAPPING_ORDER_RESULTS);
- *  *}
+ * }
  *
  * @see NamedNativeQuery#resultSetMapping
  * @see NamedStoredProcedureQuery#resultSetMappings

--- a/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
+++ b/api/src/main/java/jakarta/persistence/SqlResultSetMapping.java
@@ -31,10 +31,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Specifies an explicit mapping of the columns of a result set of a native
  * SQL query or stored procedure to {@linkplain EntityResult entity classes},
  * {@linkplain ColumnResult scalar values}, and {@linkplain ConstructorResult
- * Java class constructors}. Every SQL result set mapping has a {@link #name},
- * which may be defaulted, especially when the annotation is applied at the
- * method level. SQL result set mapping names must be unique within a
- * persistence unit.
+ * Java class constructors}. Every SQL result set mapping has a {@link #name}.
+ * SQL result set mapping names must be unique within a persistence unit.
  *
  * <p>In this example, a named mapping is declared by annotating an entity
  * class:
@@ -74,27 +72,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *         ).getResultList();
  * }
  *
- * <p>In this example, a mapping is specified by annotating a method
- * which declares a {@link jakarta.persistence.query.StaticNativeQuery},
- * and the mapping does not need to explicitly specify its name:
- * {@snippet :
- * @StaticNativeQuery("SELECT * FROM orders WHERE order_total > ?")
- * @SqlResultSetMapping(
- *     entities = @EntityResult(
- *             entityClass = Order.class,
- *             fields = {
- *                 @FieldResult(name = Order_.ID, column = "order_id"),
- *                 @FieldResult(name = Order_.TOTAL, column = "order_total"),
- *                 @FieldResult(name = Order_.ITEM, column = "order_item")
- *             }
- *     )
- * )
- * List<Order> largeOrders(int threshold) {
- *     return entityManager.createQuery(Shop_.largeOrders(threshold))
- *             .getResultList();
- * }
- * }
- *
  * <p>A {@code SqlResultSetMapping} may be reified at runtime as
  * an instance of {@link jakarta.persistence.sql.ResultSetMapping}.
  * A reified representation of a {@code SqlResultSetMapping} known
@@ -107,10 +84,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *              .get(Order_.MAPPING_ORDER_RESULTS);
  *  *}
  *
- * @see Query
- * @see StoredProcedureQuery
- * @see NamedNativeQuery
- * @see NamedStoredProcedureQuery
+ * @see NamedNativeQuery#resultSetMapping
+ * @see NamedStoredProcedureQuery#resultSetMappings
+ * @see EntityHandler#createNativeQuery(String, String)
  *
  * @see jakarta.persistence.sql.ResultSetMapping
  * @see jakarta.persistence.sql.CompoundMapping
@@ -125,21 +101,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 public @interface SqlResultSetMapping {
 
     /** 
-     * The name given to the result set mapping, and used to
-     * refer to it in the methods of the {@link Query} and
-     * {@link StoredProcedureQuery} APIs. If not specified,
-     * the name is assigned a default value depending on
-     * where the annotation occurs.
+     * The name given to the result set mapping. This name
+     * identifies the mapping in:
      * <ul>
-     * <li>If the annotation occurs on a type, the name
-     * defaults to the unqualified name of the type.
-     * <li>Otherwise, if the annotation occurs on a member
-     * of a type, the name defaults to the concatenation of
-     * the unqualified name of the type, with the string
-     * {@code "."}, and the name of the annotated member.
+     * <li>methods of {@link EntityHandler} and
+     *     {@link EntityManagerFactory}, and
+     * <li>in {@link NamedNativeQuery#resultSetMapping} and
+     *     {@link NamedStoredProcedureQuery#resultSetMappings}.
      * </ul>
      */
-    String name() default "";
+    String name();
 
     /**
      * Specifies the result set mapping to entities.

--- a/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
+++ b/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
@@ -113,6 +113,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Book getBookWithIsbn(String isbn);
  * }
  *
+ * <p>When more than one result mapping annotation is specified, each
+ * row of the mapped query result set is represented as an instance of
+ * {@code Object[]} whose elements are, in order:
+ * <ol>
+ * <li>any entity results, in the order in which they are declared;
+ * <li>any constructor results, in the order in which they are declared;
+ *     and then
+ * <li>any scalar results, in the order in which they are declared.
+ * </ol>
+ *
  * <p> An implementation of Jakarta Data backed by Jakarta Persistence
  * must treat this annotation as a Jakarta Data query annotation.
  *

--- a/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
+++ b/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
@@ -99,17 +99,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * string {@code "."}, and the name of the annotated member, for example,
  * {@code "Library.getBookWithIsbn"}.
  *
- * <p> If a {@link jakarta.persistence.SqlResultSetMapping} exists with
- * the same name as the query, it is used to map the result set of the
- * query. If the {@code @SqlResultSetMapping} annotation occurs on the
- * method with the {@code @StaticNativeQuery} annotation, name defaulting
- * rules conspire to ensure that no name needs to be explicitly specified.
+ * <p> A {@linkplain jakarta.persistence.SqlResultSetMapping result set
+ * mapping} may be specified by annotating the method with one or more
+ * {@link jakarta.persistence.EntityResult},
+ * {@link jakarta.persistence.ColumnResult}, or
+ * {@link jakarta.persistence.ConstructorResult} annotations. The inferred
+ * result set mapping has the same name as the query.
  * {@snippet :
  * @StaticNativeQuery("select * from books where isbn = ?")
- * @SqlResultSetMapping(entities =
- *         @EntityResult(entityClass = Book.class,
- *                 fields = {@FieldResult(name = "isbn", column = "isbn_13"),
- *                           @FieldResult(name = "title", column = "title_en")}))
+ * @EntityResult(entityClass = Book.class,
+ *     fields = {@FieldResult(name = Book_.ISBN, column = "isbn_13"),
+ *               @FieldResult(name = Book_.TITLE, column = "title_en")})
  * Book getBookWithIsbn(String isbn);
  * }
  *

--- a/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
+++ b/api/src/main/java/jakarta/persistence/query/StaticNativeQuery.java
@@ -117,10 +117,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * row of the mapped query result set is represented as an instance of
  * {@code Object[]} whose elements are, in order:
  * <ol>
- * <li>any entity results, in the order in which they are declared;
- * <li>any constructor results, in the order in which they are declared;
+ * <li>entity results, in the order in which they are declared;
+ * <li>constructor results, in the order in which they are declared;
  *     and then
- * <li>any scalar results, in the order in which they are declared.
+ * <li>scalar results, in the order in which they are declared.
  * </ol>
  *
  * <p> An implementation of Jakarta Data backed by Jakarta Persistence

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -3589,7 +3589,7 @@ When executed, this query will return a
 collection of all `Order` entities for items named “widget”.
 
 The `SqlResultSetMapping` metadata
-annotation—which is designed to handle more complex cases—can be used as
+annotation--which is designed to handle more complex cases--can be used as
 an alternative here. See <<a13797>> for the definition of the
 `SqlResultSetMapping` metadata annotation and related annotations.
 

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -3871,7 +3871,7 @@ above in <<constructor-results>>, or a basic type, as described in
 
 - When a `SqlResultSetMapping` specifies exactly one `EntityResult`,
   `ConstructorResult`, or `ColumnResult`, each row of the SQL result
-  set maps to query result whose type is the `entityClass` specified
+  set maps to a query result whose type is the `entityClass` specified
   by the `EntityResult`, `targetClass` specified by the `ConstructorResult`,
   or `type` specified by (or inferred from) the `ColumnResult`.
 
@@ -3882,7 +3882,7 @@ above in <<constructor-results>>, or a basic type, as described in
   * entity results, in the order in which they are declared by the
     `entities` element;
   * constructor results, in the order in which they are declared by
-    the `classes` element; and
+    the `classes` element; and then
   * scalar results, in the order in which they are declared by
     the `columns` element.
 

--- a/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
+++ b/spec/src/main/asciidoc/ch10-metadata-annotations.adoc
@@ -598,13 +598,15 @@ respectively.
 
 [source,java]
 ----
-@Target({})
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(EntityResult.EntityResults.class)
 public @interface EntityResult {
     Class<?> entityClass();
     LockModeType lockMode() default LockModeType.NONE;
     FieldResult[] fields() default {};
     String discriminatorColumn() default "";
+    ...
 }
 ----
 
@@ -638,11 +640,13 @@ the SELECT list—i.e., column alias, if applicable.
 
 [source,java]
 ----
-@Target(value={})
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(ConstructorResult.ConstructorResults.class)
 public @interface ConstructorResult {
     Class<?> targetClass();
     ColumnResult[] columns();
+    ...
 }
 ----
 
@@ -654,11 +658,13 @@ list to the arguments of the intended constructor.
 
 [source,java]
 ----
-@Target({})
+@Target(METHOD)
 @Retention(RUNTIME)
+@Repeatable(ColumnResult.ColumnResults.class)
 public @interface ColumnResult {
     String name();
     Class<?> type() default void.class;
+    ...
 }
 ----
 


### PR DESCRIPTION
- roll back some changes to @SqlResultSetMapping
- allow @XxxxResult at the method level for a @StaticNativeQuery

see #961