### PR TITLE
resolve issue-1010

### DIFF
--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
@@ -363,9 +363,7 @@ public class Client extends PMClientBase {
 
 		try {
 			getEntityTransaction().begin();
-			Employee4 emp = getEntityManager().find(Employee4.class, 8);
-			logger.log(Logger.Level.TRACE, "Name:" + emp.getLastName());
-			Department4 dept = emp.getDepartment();
+			Department4 dept = getEntityManager().find(Department4.class, 7);
 			logger.log(Logger.Level.TRACE, "Dept=" + dept.getName());
 			Map<Numbers, EmbeddedEmployee> emps = dept.getLastNameEmployees();
 			if (TestUtil.traceflag) {
@@ -560,13 +558,6 @@ public class Client extends PMClientBase {
 				}
 			}
 
-			logger.log(Logger.Level.TRACE, "Persist Employee4 ");
-			for (Employee4 emp : empRef4) {
-				if (emp != null) {
-					getEntityManager().persist(emp);
-					logger.log(Logger.Level.TRACE, "persisted Employee4 " + emp.getId());
-				}
-			}
 			// Merge Department
 			logger.log(Logger.Level.TRACE, "Merge Department ");
 			for (Department dept : deptRef) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Department4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Department4.java
@@ -18,18 +18,7 @@ package ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated;
 
 import java.util.Map;
 
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.MapKeyEnumerated;
-import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
+import jakarta.persistence.*;
 
 @Entity
 @Table(name = "DEPARTMENT2")
@@ -39,11 +28,20 @@ public class Department4 implements java.io.Serializable {
 
 	// Instance variables
 	@Id
+	@Column(name = "ID")
 	private int id;
 
+	@Column(name = "NAME")
 	private String name;
 
-	@Transient
+	@ElementCollection(targetClass = EmbeddedEmployee.class)
+	@CollectionTable(name = "EMP_MAPKEYCOL2", joinColumns = @JoinColumn(name = "FK_DEPT5"))
+	@AttributeOverrides({
+			@AttributeOverride(name = "value.employeeId", column = @Column(name = "ID")),
+			@AttributeOverride(name = "value.employeeName", column = @Column(name = "LASTNAME"))
+	})
+	@MapKeyEnumerated(EnumType.STRING)
+	@MapKeyColumn(name = "LASTNAMEEMPLOYEES_KEY")
 	private Map<Numbers, EmbeddedEmployee> lastNameEmployees;
 
 	public Department4() {
@@ -57,7 +55,6 @@ public class Department4 implements java.io.Serializable {
 	// ===========================================================
 	// getters and setters for the state fields
 
-	@Column(name = "ID")
 	public int getId() {
 		return id;
 	}
@@ -66,7 +63,6 @@ public class Department4 implements java.io.Serializable {
 		this.id = id;
 	}
 
-	@Column(name = "NAME")
 	public String getName() {
 		return name;
 	}
@@ -78,11 +74,6 @@ public class Department4 implements java.io.Serializable {
 	// ===========================================================
 	// getters and setters for the association fields
 
-	@ElementCollection(targetClass = EmbeddedEmployee.class)
-	@CollectionTable(name = "EMP_MAPKEYCOL2", joinColumns = @JoinColumn(name = "FK_DEPT5"))
-	@AttributeOverrides({ @AttributeOverride(name = "employeeId", column = @Column(name = "ID")),
-			@AttributeOverride(name = "employeeName", column = @Column(name = "LASTNAME")) })
-	@MapKeyEnumerated(EnumType.STRING)
 	public Map<Numbers, EmbeddedEmployee> getLastNameEmployees() {
 		return lastNameEmployees;
 	}


### PR DESCRIPTION
**Fixes Issue**: #1010  
**Related to**: jakartaee/platform-tck#2678

### Description of Changes
This PR standardizes `Department4` to use a consistent, implicit `FIELD` access strategy. The previous usage of mixed field/property annotations without an explicit `@Access` definition resulted in undefined behavior under Jakarta Persistence specifications.

Correcting the access strategy to properly evaluate the `@ElementCollection` revealed a few domino-effect issues that are also resolved in this PR:

1. **Map Key Column Explicit Definition** 
   Activating the field-accessed collection caused the provider to enforce the mapping. Because an explicit `@MapKeyColumn` was missing, it fell back to a default, causing a `lastnameemployees_key column does not exist` error. This PR adds `@MapKeyColumn(name = "LASTNAMEEMPLOYEES_KEY")` and aligns the `@AttributeOverrides` spec (`value.employeeId`, `value.employeeName`) appropriately.
2. **Resolved Table Collision**
   Both `Employee4` (as an `@Entity`) and `Department4.lastNameEmployees` (as an `@ElementCollection`) map to the same `EMP_MAPKEYCOL2` table. Persisting both caused a duplicate key violation (`ConstraintViolationException`) on `PK_EMP2`. The `elementCollectionTest` setup is adjusted in this PR to load `Department4` directly, stopping the independent persistence of `Employee4`.

### Why this targets the `main` branch
Because this properly maps the element collection, it inherently involves **schema/SQL generation changes** that are implementation-specific. Implementers using custom DDL scripts (for example, the equivalent of `derby.ddl.persistence.sql` in previous environments) will need to add the `LASTNAMEEMPLOYEES_KEY` column:

```sql
CREATE TABLE EMP_MAPKEYCOL2 (
    ID INT NOT NULL, 
    LASTNAMEEMPLOYEES_KEY VARCHAR(255), 
    LASTNAME VARCHAR(255), 
    THEDATE DATE, 
    FK_DEPT5 INT,  
    CONSTRAINT PK_EMP2 PRIMARY KEY (ID)
);
```

Targeting the `main` branch prevents surprisingly breaking existing `11.0.x` vendor CI test environments by giving implementations an entire development cycle to update their underlying DDL scripts.