### PR TITLE
Switch to the newer version of parent project

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -93,7 +93,7 @@ pipeline {
                                 sh "mvn clean deploy -Poss-release -DskipTests=true -Dstatus=${params.SPEC_STATUS}"
 
                                 // reset the version back to dev:
-                                sh "mvn clean versions:set -DnewVersion=${params.DEVELOPMENT_VERSION} -DgenerateBackupPoms=false"
+                                sh "mvn versions:set -DnewVersion=${params.DEVELOPMENT_VERSION} -DgenerateBackupPoms=false"
 
                                 // commit the dev version and push all back to git:
                                 sh "git commit -a -m '[Jenkins release job] Preparing next development iteration'"

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0-M1</version>
+        <version>2.0.2</version>
         <relativePath/>
     </parent>
 

--- a/tck/bin/pom.xml
+++ b/tck/bin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0-M1</version>
+        <version>2.0.2</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
which is configured to wait only for validation when deploying to Maven Central... which means less chances that the release job will timeout while waiting for Maven Central