### PR TITLE
add TCK tests for untested features of JPA 3.2

### DIFF
--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/Client.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.configuration;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.PersistenceConfiguration;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".ProgrammaticEntity"};
+        return createDeploymentJar("jpa_jpa32_configuration.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        removeTestJarFromCP();
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 programmatic persistence unit bootstrap via
+     * {@link PersistenceConfiguration}. The test verifies configuration of a
+     * provider, managed class, and properties without a persistence descriptor,
+     * and then uses the resulting factory to persist and find an entity.
+     */
+    @Test
+    public void persistenceConfigurationProgrammaticBootstrapTest() {
+        Map<String, Object> properties = new HashMap<>();
+        getPersistenceUnitProperties().forEach((key, value) -> properties.put((String) key, value));
+
+        PersistenceConfiguration configuration =
+                new PersistenceConfiguration("JPATCK-JPA32-PROGRAMMATIC")
+                        .provider((String) properties.get(JAKARTA_PERSISTENCE_PROVIDER))
+                        .managedClass(ProgrammaticEntity.class)
+                        .properties(properties);
+
+        assertEquals("JPATCK-JPA32-PROGRAMMATIC", configuration.name());
+        assertEquals(List.of(ProgrammaticEntity.class), configuration.managedClasses());
+        assertEquals("jakarta.persistence.jdbc.url", PersistenceConfiguration.JDBC_URL);
+        assertEquals("jakarta.persistence.schema-generation.database.action",
+                PersistenceConfiguration.SCHEMAGEN_DATABASE_ACTION);
+
+        try (EntityManagerFactory emf = configuration.createEntityManagerFactory()) {
+            try {
+                emf.runInTransaction(em -> em.persist(new ProgrammaticEntity(1, "programmatic")));
+                ProgrammaticEntity found =
+                        emf.callInTransaction(em -> em.find(ProgrammaticEntity.class, 1));
+                assertNotNull(found);
+                assertEquals("programmatic", found.getName());
+            } finally {
+                emf.getSchemaManager().truncate();
+            }
+        }
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/ProgrammaticEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/ProgrammaticEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.configuration;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32ProgrammaticEntity")
+@Table(name = "JPA32_PROGRAMMATIC_ENTITY")
+public class ProgrammaticEntity {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public ProgrammaticEntity() {
+    }
+
+    public ProgrammaticEntity(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.entitytype;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+import jakarta.persistence.metamodel.EntityType;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".EntityTypeBook", packageName + ".EntityTypePublisher"};
+        return createDeploymentJar("jpa_jpa32_criteria_entitytype.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API overloads that accept
+     * {@link EntityType} objects. The test verifies using an {@code EntityType}
+     * to create roots for both a top-level query and a subquery.
+     */
+    @Test
+    public void subqueryEntityTypeTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        EntityType<EntityTypeBook> bookType = em.getMetamodel().entity(EntityTypeBook.class);
+
+        CriteriaQuery<String> criteria = cb.createQuery(String.class);
+        Root<EntityTypeBook> book = criteria.from(bookType);
+        Subquery<EntityTypeBook> subquery = criteria.subquery(bookType);
+        Root<EntityTypeBook> subBook = subquery.from(bookType);
+        subquery.select(subBook)
+                .where(cb.and(List.of(
+                        subBook.get("id").equalTo(book.get("id")),
+                        subBook.get("category").equalTo("tech"))));
+        criteria.select(book.get("title"))
+                .where(cb.exists(subquery));
+
+        assertEquals("Gamma", em.createQuery(criteria).getSingleResult());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API joins using metamodel
+     * {@link EntityType} objects. The test verifies joining from an entity root
+     * to another entity type and applying an {@code ON} predicate to that join.
+     */
+    @Test
+    public void joinEntityTypeTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        EntityType<EntityTypeBook> bookType = em.getMetamodel().entity(EntityTypeBook.class);
+        EntityType<EntityTypePublisher> publisherType = em.getMetamodel().entity(EntityTypePublisher.class);
+
+        CriteriaQuery<String> criteria = cb.createQuery(String.class);
+        Root<EntityTypeBook> book = criteria.from(bookType);
+        Join<EntityTypeBook, EntityTypePublisher> publisher = book.join(publisherType);
+        publisher.on(cb.equal(book.get("publisher"), publisher));
+        criteria.select(book.get("title"))
+                .where(publisher.get("name").equalTo("Acme"))
+                .orderBy(cb.asc(book.get("id")));
+
+        assertIterableEquals(List.of("Alpha", "Gamma"), em.createQuery(criteria).getResultList());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        EntityTypePublisher acme = new EntityTypePublisher(1, "Acme");
+        EntityTypePublisher orbit = new EntityTypePublisher(2, "Orbit");
+        getEntityManager().persist(acme);
+        getEntityManager().persist(orbit);
+        getEntityManager().persist(new EntityTypeBook(1, "Alpha", "fiction", acme));
+        getEntityManager().persist(new EntityTypeBook(2, "Beta", "fiction", orbit));
+        getEntityManager().persist(new EntityTypeBook(3, "Gamma", "tech", acme));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/EntityTypeBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/EntityTypeBook.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.entitytype;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32EntityTypeBook")
+@Table(name = "JPA32_ENTITY_TYPE_BOOK")
+public class EntityTypeBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Column(name = "CATEGORY")
+    private String category;
+
+    @ManyToOne
+    @JoinColumn(name = "PUBLISHER_ID")
+    private EntityTypePublisher publisher;
+
+    public EntityTypeBook() {
+    }
+
+    public EntityTypeBook(Integer id, String title, String category, EntityTypePublisher publisher) {
+        this.id = id;
+        this.title = title;
+        this.category = category;
+        this.publisher = publisher;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/EntityTypePublisher.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/EntityTypePublisher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.entitytype;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32EntityTypePublisher")
+@Table(name = "JPA32_ENTITY_TYPE_PUBLISHER")
+public class EntityTypePublisher {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public EntityTypePublisher() {
+    }
+
+    public EntityTypePublisher(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.functions;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.LocalDateField;
+import jakarta.persistence.criteria.Root;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".CriteriaFunctionBook"};
+        return createDeploymentJar("jpa_jpa32_criteria_functions.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API expression additions. The test
+     * verifies extracting a {@link LocalDateField} value from a date expression,
+     * casting an expression to another Java type, and using the new
+     * expression-level {@code notEqualTo} predicate builder.
+     */
+    @Test
+    public void criteriaExtractCastAndNotEqualToTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<String> criteria = cb.createQuery(String.class);
+        Root<CriteriaFunctionBook> book = criteria.from(CriteriaFunctionBook.class);
+
+        Expression<Integer> publishedYear = cb.extract(LocalDateField.YEAR, book.get("publishedOn"));
+        Expression<Integer> code = book.<String>get("code").cast(Integer.class);
+        criteria.select(book.get("title"))
+                .where(List.of(
+                        publishedYear.equalTo(2024),
+                        book.get("title").notEqualTo("Alpha"),
+                        cb.gt(code, 10)));
+
+        assertEquals("Beta", em.createQuery(criteria).getSingleResult());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API string function additions.
+     * The test verifies criteria construction for {@code left}, {@code right},
+     * {@code replace}, and list-based string concatenation.
+     */
+    @Test
+    public void criteriaStringFunctionsTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+        CriteriaQuery<String> criteria = cb.createQuery(String.class);
+        Root<CriteriaFunctionBook> book = criteria.from(CriteriaFunctionBook.class);
+
+        criteria.select(cb.concat(List.of(
+                        cb.left(book.get("title"), 2),
+                        cb.literal(":"),
+                        cb.right(book.get("title"), 2),
+                        cb.literal(":"),
+                        cb.replace(book.get("title"), "Alpha", "A"))))
+                .where(book.get("id").equalTo(1));
+
+        assertEquals("Al:ha:A", em.createQuery(criteria).getSingleResult());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new CriteriaFunctionBook(1, "Alpha", "10", LocalDate.of(2024, 1, 15)));
+        getEntityManager().persist(new CriteriaFunctionBook(2, "Beta", "20", LocalDate.of(2024, 6, 1)));
+        getEntityManager().persist(new CriteriaFunctionBook(3, "Gamma", "30", LocalDate.of(2025, 3, 20)));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/CriteriaFunctionBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/CriteriaFunctionBook.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.functions;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDate;
+
+@Entity(name = "Jpa32CriteriaFunctionBook")
+@Table(name = "JPA32_CRITERIA_BOOK")
+public class CriteriaFunctionBook {
+
+    @Id
+    private Integer id;
+
+    private String title;
+
+    private String code;
+
+    private LocalDate publishedOn;
+
+    public CriteriaFunctionBook() {
+    }
+
+    public CriteriaFunctionBook(Integer id, String title, String code, LocalDate publishedOn) {
+        this.id = id;
+        this.title = title;
+        this.code = code;
+        this.publishedOn = publishedOn;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public LocalDate getPublishedOn() {
+        return publishedOn;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.list;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Tuple;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Nulls;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Selection;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".CriteriaListBook"};
+        return createDeploymentJar("jpa_jpa32_criteria_list.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API list-based predicate overloads.
+     * The test verifies {@code where(List)}, {@code having(List)},
+     * {@code and(List)}, and {@code or(List)} when building query restrictions.
+     */
+    @Test
+    public void criteriaWhereHavingAndOrListOverloadsTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<String> whereCriteria = cb.createQuery(String.class);
+        Root<CriteriaListBook> whereBook = whereCriteria.from(CriteriaListBook.class);
+        Predicate fiction = whereBook.get("category").equalTo("fiction");
+        Predicate beta = whereBook.get("title").equalTo("Beta");
+        Predicate quantityTwenty = whereBook.get("quantity").equalTo(20);
+        Predicate quantityImpossible = whereBook.get("quantity").equalTo(999);
+        whereCriteria.select(whereBook.get("title"))
+                .where(List.of(
+                        cb.and(List.of(fiction, beta)),
+                        cb.or(List.of(quantityTwenty, quantityImpossible))));
+        assertEquals("Beta", em.createQuery(whereCriteria).getSingleResult());
+
+        CriteriaQuery<String> havingCriteria = cb.createQuery(String.class);
+        Root<CriteriaListBook> havingBook = havingCriteria.from(CriteriaListBook.class);
+        Expression<String> category = havingBook.get("category");
+        havingCriteria.select(category)
+                .groupBy(List.of(category))
+                .having(List.of(cb.gt(cb.count(havingBook), 1L)));
+        assertEquals("fiction", em.createQuery(havingCriteria).getSingleResult());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API list-based selection and
+     * expression overloads. The test verifies {@code array(List)},
+     * {@code tuple(List)}, and {@code concat(List)} query construction.
+     */
+    @Test
+    public void criteriaArrayTupleAndConcatListOverloadsTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<Object[]> arrayCriteria = cb.createQuery(Object[].class);
+        Root<CriteriaListBook> arrayBook = arrayCriteria.from(CriteriaListBook.class);
+        List<Selection<?>> arraySelections =
+                List.of(arrayBook.get("title"), arrayBook.get("quantity"));
+        arrayCriteria.select(cb.array(arraySelections))
+                .where(arrayBook.get("id").equalTo(1));
+        Object[] arrayResult = em.createQuery(arrayCriteria).getSingleResult();
+        assertEquals("Alpha", arrayResult[0]);
+        assertEquals(10, arrayResult[1]);
+
+        CriteriaQuery<Tuple> tupleCriteria = cb.createTupleQuery();
+        Root<CriteriaListBook> tupleBook = tupleCriteria.from(CriteriaListBook.class);
+        List<Selection<?>> tupleSelections =
+                List.of(tupleBook.get("title").alias("title"),
+                        tupleBook.get("quantity").alias("quantity"));
+        tupleCriteria.select(cb.tuple(tupleSelections))
+                .where(tupleBook.get("id").equalTo(1));
+        Tuple tuple = em.createQuery(tupleCriteria).getSingleResult();
+        assertEquals("Alpha", tuple.get("title", String.class));
+        assertEquals(10, tuple.get("quantity", Integer.class));
+
+        CriteriaQuery<String> concatCriteria = cb.createQuery(String.class);
+        Root<CriteriaListBook> concatBook = concatCriteria.from(CriteriaListBook.class);
+        concatCriteria.select(cb.concat(List.<Expression<String>>of(
+                        concatBook.get("title"),
+                        cb.literal(":"),
+                        concatBook.get("category"))))
+                .where(concatBook.get("id").equalTo(1));
+        assertEquals("Alpha:fiction", em.createQuery(concatCriteria).getSingleResult());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API null ordering support. The test
+     * verifies that {@link Nulls#FIRST} and {@link Nulls#LAST} can be supplied
+     * when building order expressions.
+     */
+    @Test
+    public void criteriaNullPrecedenceTest() {
+        EntityManager em = getEntityManager();
+        CriteriaBuilder cb = em.getCriteriaBuilder();
+
+        CriteriaQuery<Integer> nullsFirstCriteria = cb.createQuery(Integer.class);
+        Root<CriteriaListBook> nullsFirstBook = nullsFirstCriteria.from(CriteriaListBook.class);
+        nullsFirstCriteria.select(nullsFirstBook.get("id"))
+                .orderBy(List.of(
+                        cb.asc(nullsFirstBook.get("nullableLabel"), Nulls.FIRST),
+                        cb.asc(nullsFirstBook.get("id"))));
+        List<Integer> nullsFirst = em.createQuery(nullsFirstCriteria).getResultList();
+        assertEquals(1, nullsFirst.get(0));
+
+        CriteriaQuery<Integer> nullsLastCriteria = cb.createQuery(Integer.class);
+        Root<CriteriaListBook> nullsLastBook = nullsLastCriteria.from(CriteriaListBook.class);
+        nullsLastCriteria.select(nullsLastBook.get("id"))
+                .orderBy(List.of(
+                        cb.asc(nullsLastBook.get("nullableLabel"), Nulls.LAST),
+                        cb.asc(nullsLastBook.get("id"))));
+        List<Integer> nullsLast = em.createQuery(nullsLastCriteria).getResultList();
+        assertEquals(1, nullsLast.get(nullsLast.size() - 1));
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new CriteriaListBook(1, "Alpha", "fiction", null, 10));
+        getEntityManager().persist(new CriteriaListBook(2, "Beta", "fiction", "bravo", 20));
+        getEntityManager().persist(new CriteriaListBook(3, "Gamma", "tech", "charlie", 30));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/CriteriaListBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/CriteriaListBook.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.list;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32CriteriaListBook")
+@Table(name = "JPA32_CRITERIA_LIST_BOOK")
+public class CriteriaListBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Column(name = "CATEGORY")
+    private String category;
+
+    @Column(name = "NULLABLE_LABEL")
+    private String nullableLabel;
+
+    @Column(name = "QUANTITY")
+    private Integer quantity;
+
+    public CriteriaListBook() {
+    }
+
+    public CriteriaListBook(Integer id, String title, String category, String nullableLabel,
+            Integer quantity) {
+        this.id = id;
+        this.title = title;
+        this.category = category;
+        this.nullableLabel = nullableLabel;
+        this.quantity = quantity;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.setops;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaSelect;
+import jakarta.persistence.criteria.Root;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".SetOpsBook"};
+        return createDeploymentJar("jpa_jpa32_criteria_setops.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 Criteria API set operation support. The test
+     * verifies that {@code union}, {@code intersect}, and {@code except} combine
+     * compatible criteria select queries with the expected set semantics.
+     */
+    @Test
+    public void criteriaSelectSetOperationsTest() {
+        CriteriaBuilder cb = getEntityManager().getCriteriaBuilder();
+
+        CriteriaQuery<String> first = cb.createQuery(String.class);
+        Root<SetOpsBook> firstBook = first.from(SetOpsBook.class);
+        first.select(firstBook.get("title"))
+                .where(cb.le(firstBook.get("quantity"), 20));
+
+        CriteriaQuery<String> second = cb.createQuery(String.class);
+        Root<SetOpsBook> secondBook = second.from(SetOpsBook.class);
+        second.select(secondBook.get("title"))
+                .where(secondBook.get("title").in(List.of("Beta", "Gamma")));
+
+        CriteriaSelect<String> union = cb.union(first, second);
+        assertEquals(Set.of("Alpha", "Beta", "Gamma"),
+                new HashSet<>(getEntityManager().createQuery(union).getResultList()));
+
+        CriteriaSelect<String> intersect = cb.intersect(first, second);
+        assertEquals(Set.of("Beta"),
+                new HashSet<>(getEntityManager().createQuery(intersect).getResultList()));
+
+        CriteriaSelect<String> except = cb.except(first, second);
+        assertEquals(Set.of("Alpha"),
+                new HashSet<>(getEntityManager().createQuery(except).getResultList()));
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new SetOpsBook(1, "Alpha", 10));
+        getEntityManager().persist(new SetOpsBook(2, "Beta", 20));
+        getEntityManager().persist(new SetOpsBook(3, "Gamma", 30));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/SetOpsBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/SetOpsBook.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.criteria.setops;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32SetOpsBook")
+@Table(name = "JPA32_SET_OPS_BOOK")
+public class SetOpsBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Column(name = "QUANTITY")
+    private Integer quantity;
+
+    public SetOpsBook() {
+    }
+
+    public SetOpsBook(Integer id, String title, Integer quantity) {
+        this.id = id;
+        this.title = title;
+        this.quantity = quantity;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.entitymanager;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Query;
+import jakarta.persistence.Timeout;
+import jakarta.persistence.TypedQuery;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".EntityManagerBook"};
+        return createDeploymentJar("jpa_jpa32_entitymanager.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 timeout option support for entity manager
+     * locking. The test verifies the {@code EntityManager.lock(entity, mode,
+     * Timeout)} overload accepts a {@link Timeout} option.
+     */
+    @Test
+    public void lockOptionOverloadTest() {
+        EntityManager em = getEntityManager();
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        EntityManagerBook book = em.find(EntityManagerBook.class, 1);
+        em.lock(book, LockModeType.NONE, Timeout.seconds(1));
+        transaction.commit();
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 cache mode convenience accessors. The test
+     * verifies setting and reading cache retrieve/store modes directly on
+     * {@link EntityManager} and {@link TypedQuery}.
+     */
+    @Test
+    public void entityManagerAndQueryCacheModesTest() {
+        EntityManager em = getEntityManager();
+        em.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+        em.setCacheStoreMode(CacheStoreMode.BYPASS);
+        assertEquals(CacheRetrieveMode.BYPASS, em.getCacheRetrieveMode());
+        assertEquals(CacheStoreMode.BYPASS, em.getCacheStoreMode());
+
+        TypedQuery<EntityManagerBook> typedQuery =
+                em.createQuery("SELECT b FROM Jpa32EntityManagerBook b ORDER BY b.id", EntityManagerBook.class);
+        typedQuery.setCacheRetrieveMode(CacheRetrieveMode.BYPASS);
+        typedQuery.setCacheStoreMode(CacheStoreMode.USE);
+        assertEquals(CacheRetrieveMode.BYPASS, typedQuery.getCacheRetrieveMode());
+        assertEquals(CacheStoreMode.USE, typedQuery.getCacheStoreMode());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new EntityManagerBook(1, "Alpha"));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/EntityManagerBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/EntityManagerBook.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.entitymanager;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32EntityManagerBook")
+@Table(name = "JPA32_ENTITY_MANAGER_BOOK")
+public class EntityManagerBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    public EntityManagerBook() {
+    }
+
+    public EntityManagerBook(Integer id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.entityresult;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityResult;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.SqlResultSetMapping;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".EntityResultBook"};
+        return createDeploymentJar("jpa_jpa32_entityresult.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests the Jakarta Persistence 3.2 {@link EntityResult#lockMode()}
+     * annotation element. The test verifies that the mapping exposes the
+     * configured optimistic lock mode and that a native query using the
+     * {@link SqlResultSetMapping} can materialize the mapped entity.
+     */
+    @Test
+    public void entityResultLockModeTest() {
+        SqlResultSetMapping mapping = EntityResultBook.class.getAnnotation(SqlResultSetMapping.class);
+        EntityResult entityResult = mapping.entities()[0];
+        assertEquals(LockModeType.OPTIMISTIC, entityResult.lockMode());
+
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        EntityResultBook book = getEntityManager()
+                .createNamedQuery(EntityResultBook.QUERY_WITH_LOCK_MODE, EntityResultBook.class)
+                .getSingleResult();
+        assertEquals("locked", book.getTitle());
+        transaction.commit();
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new EntityResultBook(1, "locked"));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/EntityResultBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/EntityResultBook.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.entityresult;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityResult;
+import jakarta.persistence.FieldResult;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+@NamedNativeQuery(
+        name = EntityResultBook.QUERY_WITH_LOCK_MODE,
+        query = "SELECT ID, TITLE, VERSION FROM JPA32_ER_BOOK WHERE ID = 1",
+        resultSetMapping = EntityResultBook.RESULT_MAPPING)
+@SqlResultSetMapping(
+        name = EntityResultBook.RESULT_MAPPING,
+        entities = @EntityResult(
+                entityClass = EntityResultBook.class,
+                lockMode = LockModeType.OPTIMISTIC,
+                fields = {
+                        @FieldResult(name = "id", column = "ID"),
+                        @FieldResult(name = "title", column = "TITLE"),
+                        @FieldResult(name = "version", column = "VERSION")
+                }))
+@Entity(name = "Jpa32EntityResultBook")
+@Table(name = "JPA32_ER_BOOK")
+public class EntityResultBook {
+
+    static final String QUERY_WITH_LOCK_MODE = "Jpa32EntityResultBook.withLockMode";
+
+    static final String RESULT_MAPPING = "Jpa32EntityResultBook.lockModeMapping";
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Version
+    @Column(name = "VERSION")
+    private Integer version;
+
+    public EntityResultBook() {
+    }
+
+    public EntityResultBook(Integer id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/BookStatus.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/BookStatus.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.enumeratedvalue;
+
+import jakarta.persistence.EnumeratedValue;
+
+public enum BookStatus {
+    DRAFT("D"),
+    PUBLISHED("P");
+
+    @EnumeratedValue
+    private final String code;
+
+    BookStatus(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.enumeratedvalue;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".EnumeratedValueBook", packageName + ".BookStatus"};
+        return createDeploymentJar("jpa_jpa32_enumeratedvalue.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 {@code @EnumeratedValue} support. The test
+     * verifies that an enum value is persisted using the enum field annotated as
+     * the database value and that the entity attribute is restored as the enum
+     * constant when read back.
+     */
+    @Test
+    public void enumeratedValueTest() {
+        EnumeratedValueBook book = getEntityManager().find(EnumeratedValueBook.class, 1);
+        assertNotNull(book);
+        assertEquals(BookStatus.PUBLISHED, book.getStatus());
+
+        String storedStatus = getEntityManager()
+                .createNamedQuery(EnumeratedValueBook.QUERY_STATUS_CODE, String.class)
+                .getSingleResult();
+        assertEquals(BookStatus.PUBLISHED.getCode(), storedStatus);
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new EnumeratedValueBook(1, BookStatus.PUBLISHED));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/EnumeratedValueBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/EnumeratedValueBook.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.enumeratedvalue;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32EnumeratedValueBook")
+@Table(name = "JPA32_ENUMERATED_VALUE_BOOK")
+@NamedNativeQuery(name = EnumeratedValueBook.QUERY_STATUS_CODE,
+        query = "SELECT STATUS_CODE FROM JPA32_ENUMERATED_VALUE_BOOK WHERE ID = 1",
+        resultClass = String.class,
+        columns = @ColumnResult(name = "STATUS_CODE", type = String.class))
+public class EnumeratedValueBook {
+
+    public static final String QUERY_STATUS_CODE = "Jpa32EnumeratedValueBook.findStatusCode";
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "STATUS_CODE", length = 1)
+    private BookStatus status;
+
+    public EnumeratedValueBook() {
+    }
+
+    public EnumeratedValueBook(Integer id, BookStatus status) {
+        this.id = id;
+        this.status = status;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public BookStatus getStatus() {
+        return status;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.AttributeNode;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Graph;
+import jakarta.persistence.Subgraph;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".GraphBook", packageName + ".GraphPublisher"};
+        return createDeploymentJar("jpa_jpa32_graph.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 common {@link Graph} operations. The test
+     * verifies adding, checking, retrieving, and removing attribute nodes using
+     * both attribute names and metamodel attributes, and adding a subgraph from a
+     * metamodel attribute.
+     */
+    @Test
+    public void graphCommonOperationsTest() {
+        EntityManager em = getEntityManager();
+        EntityGraph<GraphBook> graph = em.createEntityGraph(GraphBook.class);
+        Graph<GraphBook> graphView = graph;
+        EntityType<GraphBook> bookType = em.getMetamodel().entity(GraphBook.class);
+        SingularAttribute<? super GraphBook, String> titleAttribute =
+                bookType.getSingularAttribute("title", String.class);
+        SingularAttribute<? super GraphBook, GraphPublisher> publisherAttribute =
+                bookType.getSingularAttribute("publisher", GraphPublisher.class);
+
+        graphView.addAttributeNode("title");
+        assertTrue(graphView.hasAttributeNode("title"));
+        graphView.removeAttributeNode("title");
+
+        AttributeNode<String> titleNode = graphView.addAttributeNode(titleAttribute);
+        assertEquals("title", titleNode.getAttributeName());
+        assertTrue(graphView.hasAttributeNode(titleAttribute));
+        assertEquals("title", graphView.getAttributeNode(titleAttribute).getAttributeName());
+
+        Subgraph<GraphPublisher> publisherGraph = graphView.addSubgraph(publisherAttribute);
+        publisherGraph.addAttributeNode("name");
+        assertEquals(GraphPublisher.class, publisherGraph.getClassType());
+        assertTrue(publisherGraph.hasAttributeNode("name"));
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 entity graph element subgraph creation. The
+     * test verifies creating a subgraph for collection elements by attribute
+     * name and element class.
+     */
+    @Test
+    public void graphElementSubgraphTest() {
+        EntityGraph<GraphPublisher> graph = getEntityManager().createEntityGraph(GraphPublisher.class);
+        Subgraph<GraphBook> booksGraph = graph.addElementSubgraph("books", GraphBook.class);
+        booksGraph.addAttributeNode("title");
+        assertTrue(booksGraph.hasAttributeNode("title"));
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        GraphPublisher publisher = new GraphPublisher(1, "Acme");
+        GraphBook book = new GraphBook(1, "Alpha", publisher);
+        publisher.getBooks().add(book);
+        getEntityManager().persist(publisher);
+        getEntityManager().persist(book);
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/GraphBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/GraphBook.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32GraphBook")
+@Table(name = "JPA32_GRAPH_BOOK")
+public class GraphBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PUBLISHER_ID")
+    private GraphPublisher publisher;
+
+    public GraphBook() {
+    }
+
+    public GraphBook(Integer id, String title, GraphPublisher publisher) {
+        this.id = id;
+        this.title = title;
+        this.publisher = publisher;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/GraphPublisher.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/GraphPublisher.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity(name = "Jpa32GraphPublisher")
+@Table(name = "JPA32_GRAPH_PUBLISHER")
+public class GraphPublisher {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @OneToMany(mappedBy = "publisher")
+    private Set<GraphBook> books = new HashSet<>();
+
+    public GraphPublisher() {
+    }
+
+    public GraphPublisher(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Set<GraphBook> getBooks() {
+        return books;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.Subgraph;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.ListAttribute;
+import jakarta.persistence.metamodel.MapAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {
+                packageName + ".GraphAdvancedAuthor",
+                packageName + ".GraphAdvancedBook",
+                packageName + ".GraphAdvancedLibrary",
+                packageName + ".GraphAdvancedPublication",
+                packageName + ".GraphAdvancedStaffAuthor"
+        };
+        return createDeploymentJar("jpa_jpa32_graph_advanced.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        getEntityManager();
+        removeTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 {@link EntityGraph} additions for building
+     * treated subgraphs from metamodel attributes. The test verifies treated
+     * subgraphs for a singular attribute, treated element subgraphs for a list
+     * attribute, and treated map-key subgraphs for a map attribute.
+     */
+    @Test
+    public void graphTreatedSubgraphsAndMapKeySubgraphTest() {
+        EntityGraph<GraphAdvancedLibrary> graph =
+                getEntityManager().createEntityGraph(GraphAdvancedLibrary.class);
+        EntityType<GraphAdvancedLibrary> libraryType =
+                getEntityManager().getMetamodel().entity(GraphAdvancedLibrary.class);
+
+        SingularAttribute<? super GraphAdvancedLibrary, GraphAdvancedPublication> featuredPublication =
+                libraryType.getSingularAttribute("featuredPublication", GraphAdvancedPublication.class);
+        Subgraph<GraphAdvancedBook> featuredBookGraph =
+                graph.addTreatedSubgraph(featuredPublication, GraphAdvancedBook.class);
+        featuredBookGraph.addAttributeNode("isbn");
+        assertEquals(GraphAdvancedBook.class, featuredBookGraph.getClassType());
+        assertTrue(featuredBookGraph.hasAttributeNode("isbn"));
+
+        ListAttribute<? super GraphAdvancedLibrary, GraphAdvancedPublication> publications =
+                libraryType.getList("publications", GraphAdvancedPublication.class);
+        Subgraph<GraphAdvancedBook> publicationBookGraph =
+                graph.addTreatedElementSubgraph(publications, GraphAdvancedBook.class);
+        publicationBookGraph.addAttributeNode("isbn");
+        assertEquals(GraphAdvancedBook.class, publicationBookGraph.getClassType());
+        assertTrue(publicationBookGraph.hasAttributeNode("isbn"));
+
+        MapAttribute<? super GraphAdvancedLibrary, GraphAdvancedAuthor, GraphAdvancedPublication> selections =
+                libraryType.getMap("selections", GraphAdvancedAuthor.class, GraphAdvancedPublication.class);
+        Subgraph<GraphAdvancedStaffAuthor> keyGraph =
+                graph.addTreatedMapKeySubgraph(selections, GraphAdvancedStaffAuthor.class);
+        keyGraph.addAttributeNode("department");
+        assertEquals(GraphAdvancedStaffAuthor.class, keyGraph.getClassType());
+        assertTrue(keyGraph.hasAttributeNode("department"));
+    }
+
+    private void removeTestData() {
+        if (getEntityTransaction().isActive()) {
+            getEntityTransaction().rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedAuthor.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedAuthor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32GraphAdvancedAuthor")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Table(name = "JPA32_GRAPH_AUTHOR")
+public class GraphAdvancedAuthor {
+
+    @Id
+    private Integer id;
+
+    private String name;
+
+    public GraphAdvancedAuthor() {
+    }
+
+    public GraphAdvancedAuthor(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedBook.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "Jpa32GraphAdvancedBook")
+public class GraphAdvancedBook extends GraphAdvancedPublication {
+
+    private String isbn;
+
+    public GraphAdvancedBook() {
+    }
+
+    public GraphAdvancedBook(Integer id, String title, String isbn) {
+        super(id, title);
+        this.isbn = isbn;
+    }
+
+    public String getIsbn() {
+        return isbn;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedLibrary.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedLibrary.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Entity(name = "Jpa32GraphAdvancedLibrary")
+@Table(name = "JPA32_GRAPH_LIBRARY")
+public class GraphAdvancedLibrary {
+
+    @Id
+    private Integer id;
+
+    private String name;
+
+    @ManyToOne
+    private GraphAdvancedPublication featuredPublication;
+
+    @OneToMany
+    @JoinTable(name = "JPA32_GRAPH_PUBS")
+    private List<GraphAdvancedPublication> publications = new ArrayList<>();
+
+    @OneToMany
+    @JoinTable(name = "JPA32_GRAPH_SELECTION")
+    private Map<GraphAdvancedAuthor, GraphAdvancedPublication> selections = new HashMap<>();
+
+    public GraphAdvancedLibrary() {
+    }
+
+    public GraphAdvancedLibrary(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public GraphAdvancedPublication getFeaturedPublication() {
+        return featuredPublication;
+    }
+
+    public List<GraphAdvancedPublication> getPublications() {
+        return publications;
+    }
+
+    public Map<GraphAdvancedAuthor, GraphAdvancedPublication> getSelections() {
+        return selections;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedPublication.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedPublication.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32GraphAdvancedPublication")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@Table(name = "JPA32_GRAPH_PUB")
+public class GraphAdvancedPublication {
+
+    @Id
+    private Integer id;
+
+    private String title;
+
+    public GraphAdvancedPublication() {
+    }
+
+    public GraphAdvancedPublication(Integer id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedStaffAuthor.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/GraphAdvancedStaffAuthor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.graph.advanced;
+
+import jakarta.persistence.Entity;
+
+@Entity(name = "Jpa32GraphAdvancedStaffAuthor")
+public class GraphAdvancedStaffAuthor extends GraphAdvancedAuthor {
+
+    private String department;
+
+    public GraphAdvancedStaffAuthor() {
+    }
+
+    public GraphAdvancedStaffAuthor(Integer id, String name, String department) {
+        super(id, name);
+        this.department = department;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.jpql;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".JpqlBook"};
+        return createDeploymentJar("jpa_jpa32_jpql.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 JPQL set operations. The test verifies that
+     * {@code UNION}, {@code INTERSECT}, and {@code EXCEPT} combine compatible
+     * select query results with the expected set semantics.
+     */
+    @Test
+    public void jpqlSetOperationsTest() {
+        List<String> union = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32JpqlBook b WHERE b.quantity <= 20 "
+                        + "UNION SELECT b.title FROM Jpa32JpqlBook b WHERE b.title IN ('Beta', 'Gamma')",
+                        String.class)
+                .getResultList();
+        assertEquals(Set.of("Alpha", "Beta", "Gamma"), new HashSet<>(union));
+
+        List<String> intersect = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32JpqlBook b WHERE b.quantity <= 20 "
+                        + "INTERSECT SELECT b.title FROM Jpa32JpqlBook b WHERE b.title IN ('Beta', 'Gamma')",
+                        String.class)
+                .getResultList();
+        assertEquals(Set.of("Beta"), new HashSet<>(intersect));
+
+        List<String> except = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32JpqlBook b WHERE b.quantity <= 20 "
+                        + "EXCEPT SELECT b.title FROM Jpa32JpqlBook b WHERE b.title IN ('Beta', 'Gamma')",
+                        String.class)
+                .getResultList();
+        assertEquals(Set.of("Alpha"), new HashSet<>(except));
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 JPQL scalar expression additions. The test
+     * verifies the string functions {@code LEFT}, {@code RIGHT}, and
+     * {@code REPLACE}, the string concatenation operator {@code ||}, and
+     * numeric conversion using {@code CAST}.
+     */
+    @Test
+    public void jpqlCastStringFunctionsAndConcatOperatorTest() {
+        String text = getEntityManager()
+                .createQuery("SELECT LEFT(b.title, 2) || ':' || RIGHT(b.title, 2) || ':' "
+                        + "|| REPLACE(b.title, 'Alpha', 'A') "
+                        + "FROM Jpa32JpqlBook b WHERE b.id = 1", String.class)
+                .getSingleResult();
+        assertEquals("Al:ha:A", text);
+
+        Number castValue = getEntityManager()
+                .createQuery("SELECT CAST(b.code AS INTEGER) + 5 FROM Jpa32JpqlBook b WHERE b.id = 1",
+                        Number.class)
+                .getSingleResult();
+        assertEquals(15, castValue.intValue());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 JPQL entity helper functions. The test
+     * verifies that {@code ID(entity)} resolves the entity identifier and
+     * {@code VERSION(entity)} resolves the entity version value.
+     */
+    @Test
+    public void jpqlIdAndVersionFunctionsTest() {
+        Integer id = getEntityManager()
+                .createQuery("SELECT ID(b) FROM Jpa32JpqlBook b WHERE b.id = 1", Integer.class)
+                .getSingleResult();
+        assertEquals(1, id);
+
+        Integer version = getEntityManager()
+                .createQuery("SELECT VERSION(b) FROM Jpa32JpqlBook b WHERE b.id = 1", Integer.class)
+                .getSingleResult();
+        assertNotNull(version);
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new JpqlBook(1, "Alpha", "10", 10));
+        getEntityManager().persist(new JpqlBook(2, "Beta", "20", 20));
+        getEntityManager().persist(new JpqlBook(3, "Gamma", "30", 30));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/JpqlBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/JpqlBook.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.jpql;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+@Entity(name = "Jpa32JpqlBook")
+@Table(name = "JPA32_JPQL_BOOK")
+public class JpqlBook {
+
+    @Id
+    private Integer id;
+
+    private String title;
+
+    private String code;
+
+    private int quantity;
+
+    @Version
+    private Integer version;
+
+    public JpqlBook() {
+    }
+
+    public JpqlBook(Integer id, String title, String code, int quantity) {
+        this.id = id;
+        this.title = title;
+        this.code = code;
+        this.quantity = quantity;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.metamodel;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.TypedQueryReference;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.StaticMetamodel;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.processing.Generated;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {
+                packageName + ".MetaBook",
+                packageName + ".MetaBook_",
+                packageName + ".MetaPublisher"
+        };
+        return createDeploymentJar("jpa_jpa32_metamodel.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 metamodel lookup by entity name. The test
+     * verifies that {@code Metamodel.entity(String)} resolves the entity type
+     * associated with the supplied entity name.
+     */
+    @Test
+    public void metamodelEntityNameTest() {
+        EntityType<?> entityByName = getEntityManager().getMetamodel().entity("Jpa32MetaBook");
+        assertEquals(MetaBook.class, entityByName.getJavaType());
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 entity manager factory metadata accessors.
+     * The test verifies typed named query references from
+     * {@code getNamedQueries(Class)} and named entity graph lookup from
+     * {@code getNamedEntityGraphs(Class)}.
+     */
+    @Test
+    public void factoryNamedQueriesAndGraphsTest() {
+        EntityManager em = getEntityManager();
+        EntityManagerFactory emf = em.getEntityManagerFactory();
+        Map<String, TypedQueryReference<MetaBook>> namedQueries =
+                emf.getNamedQueries(MetaBook.class);
+        TypedQueryReference<MetaBook> queryReference =
+                namedQueries.get(MetaBook.QUERY_BY_CATEGORY);
+        assertNotNull(queryReference);
+        List<Integer> fictionIds = em.createQuery(queryReference)
+                .setParameter("category", "fiction")
+                .getResultList()
+                .stream()
+                .map(MetaBook::getId)
+                .collect(Collectors.toList());
+        assertIterableEquals(List.of(1, 2), fictionIds);
+
+        Map<String, EntityGraph<? extends MetaBook>> namedGraphs =
+                emf.getNamedEntityGraphs(MetaBook.class);
+        assertTrue(namedGraphs.containsKey(MetaBook.GRAPH_WITH_PUBLISHER));
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 static metamodel generation requirements.
+     * The test verifies generated constants for attributes, named queries, named
+     * graphs, result set mappings, and the presence of the generated class
+     * annotation and metamodel fields.
+     */
+    @Test
+    public void staticMetamodelConstantsAndGeneratedAnnotationTest() {
+        StaticMetamodel staticMetamodel = MetaBook_.class.getAnnotation(StaticMetamodel.class);
+        assertNotNull(staticMetamodel);
+        assertEquals(MetaBook.class, staticMetamodel.value());
+        assertNotNull(MetaBook_.class_);
+        assertNotNull(MetaBook_.title);
+        assertNotNull(MetaBook_.publisher);
+        assertEquals("title", MetaBook_.TITLE);
+        assertEquals("category", MetaBook_.CATEGORY);
+        assertEquals(MetaBook.QUERY_BY_CATEGORY, MetaBook_.QUERY_JPA32_META_BOOK_FIND_BY_CATEGORY);
+        assertEquals(MetaBook.GRAPH_WITH_PUBLISHER, MetaBook_.GRAPH_JPA32_META_BOOK_WITH_PUBLISHER);
+        assertEquals(MetaBook.MAPPING_TITLE, MetaBook_.MAPPING_JPA32_META_BOOK_TITLE_MAPPING);
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        MetaPublisher acme = new MetaPublisher(1, "Acme");
+        MetaPublisher orbit = new MetaPublisher(2, "Orbit");
+        getEntityManager().persist(acme);
+        getEntityManager().persist(orbit);
+        getEntityManager().persist(new MetaBook(1, "Alpha", "fiction", acme));
+        getEntityManager().persist(new MetaBook(2, "Beta", "fiction", orbit));
+        getEntityManager().persist(new MetaBook(3, "Gamma", "tech", acme));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaBook.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.metamodel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedAttributeNode;
+import jakarta.persistence.NamedEntityGraph;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32MetaBook")
+@Table(name = "JPA32_META_BOOK")
+@NamedQuery(name = MetaBook.QUERY_BY_CATEGORY,
+        query = "SELECT b FROM Jpa32MetaBook b WHERE b.category = :category ORDER BY b.id",
+        resultClass = MetaBook.class)
+@NamedEntityGraph(name = MetaBook.GRAPH_WITH_PUBLISHER,
+        attributeNodes = @NamedAttributeNode("publisher"))
+@SqlResultSetMapping(name = MetaBook.MAPPING_TITLE,
+        columns = @ColumnResult(name = "TITLE", type = String.class))
+public class MetaBook {
+
+    public static final String QUERY_BY_CATEGORY = "Jpa32MetaBook.findByCategory";
+
+    public static final String GRAPH_WITH_PUBLISHER = "Jpa32MetaBook.withPublisher";
+
+    public static final String MAPPING_TITLE = "Jpa32MetaBookTitleMapping";
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Column(name = "CATEGORY")
+    private String category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PUBLISHER_ID")
+    private MetaPublisher publisher;
+
+    public MetaBook() {
+    }
+
+    public MetaBook(Integer id, String title, String category, MetaPublisher publisher) {
+        this.id = id;
+        this.title = title;
+        this.category = category;
+        this.publisher = publisher;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaBook_.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaBook_.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.metamodel;
+
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.TypedQueryReference;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.SingularAttribute;
+import jakarta.persistence.metamodel.StaticMetamodel;
+import jakarta.persistence.sql.ResultSetMapping;
+
+import javax.annotation.processing.Generated;
+
+@Generated("manual")
+@StaticMetamodel(MetaBook.class)
+public class MetaBook_ {
+
+    public static volatile EntityType<MetaBook> class_;
+
+    public static final String ID = "id";
+    public static final String TITLE = "title";
+    public static final String CATEGORY = "category";
+    public static final String PUBLISHER = "publisher";
+
+    public static final String QUERY_JPA32_META_BOOK_FIND_BY_CATEGORY = MetaBook.QUERY_BY_CATEGORY;
+    public static final String GRAPH_JPA32_META_BOOK_WITH_PUBLISHER = MetaBook.GRAPH_WITH_PUBLISHER;
+    public static final String MAPPING_JPA32_META_BOOK_TITLE_MAPPING = MetaBook.MAPPING_TITLE;
+
+    public static volatile SingularAttribute<MetaBook, Integer> id;
+    public static volatile SingularAttribute<MetaBook, String> title;
+    public static volatile SingularAttribute<MetaBook, String> category;
+    public static volatile SingularAttribute<MetaBook, MetaPublisher> publisher;
+
+    public static volatile TypedQueryReference<MetaBook> _Jpa32MetaBook_findByCategory_;
+    public static volatile EntityGraph<MetaBook> _Jpa32MetaBook_withPublisher;
+    public static volatile ResultSetMapping<String> _Jpa32MetaBookTitleMapping;
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaPublisher.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/MetaPublisher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.metamodel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32MetaPublisher")
+@Table(name = "JPA32_META_PUBLISHER")
+public class MetaPublisher {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public MetaPublisher() {
+    }
+
+    public MetaPublisher(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.namednativequery;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".NativeEntity", packageName + ".NativeDto"};
+        return createDeploymentJar("jpa_jpa32_namednativequery.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 {@code @NamedNativeQuery} result mapping
+     * shortcuts. The test verifies named native queries declared with entity,
+     * constructor result class, and scalar column mappings can be executed using
+     * typed query creation.
+     */
+    @Test
+    public void namedNativeQueryEntitiesClassesAndColumnsTest() {
+        NativeEntity entity = getEntityManager()
+                .createNamedQuery(NativeEntity.QUERY_ENTITY, NativeEntity.class)
+                .getSingleResult();
+        assertEquals("native-one", entity.getName());
+
+        NativeDto dto = getEntityManager()
+                .createNamedQuery(NativeEntity.QUERY_DTO, NativeDto.class)
+                .getSingleResult();
+        assertEquals(new NativeDto(1, "native-one"), dto);
+
+        String name = getEntityManager()
+                .createNamedQuery(NativeEntity.QUERY_COLUMN, String.class)
+                .getSingleResult();
+        assertEquals("native-one", name);
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new NativeEntity(1, "native-one"));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/NativeDto.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/NativeDto.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.namednativequery;
+
+public record NativeDto(Integer id, String name) {
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/NativeEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/NativeEntity.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.namednativequery;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ColumnResult;
+import jakarta.persistence.ConstructorResult;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityResult;
+import jakarta.persistence.Id;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.SqlResultSetMapping;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32NativeQueryEntity")
+@Table(name = "JPA32_NATIVE_QUERY_ENTITY")
+@NamedNativeQuery(name = NativeEntity.QUERY_ENTITY,
+        query = "SELECT ID, NAME FROM JPA32_NATIVE_QUERY_ENTITY WHERE ID = 1",
+        resultClass = NativeEntity.class,
+        entities = @EntityResult(entityClass = NativeEntity.class, lockMode = LockModeType.NONE))
+@NamedNativeQuery(name = NativeEntity.QUERY_DTO,
+        query = "SELECT ID AS ITEM_ID, NAME AS ITEM_NAME FROM JPA32_NATIVE_QUERY_ENTITY WHERE ID = 1",
+        resultClass = NativeDto.class,
+        classes = @ConstructorResult(targetClass = NativeDto.class,
+                columns = {
+                        @ColumnResult(name = "ITEM_ID", type = Integer.class),
+                        @ColumnResult(name = "ITEM_NAME", type = String.class)
+                }))
+@NamedNativeQuery(name = NativeEntity.QUERY_COLUMN,
+        query = "SELECT NAME AS ITEM_NAME FROM JPA32_NATIVE_QUERY_ENTITY WHERE ID = 1",
+        resultClass = String.class,
+        columns = @ColumnResult(name = "ITEM_NAME", type = String.class))
+@SqlResultSetMapping(name = NativeEntity.MAPPING_DTO,
+        classes = @ConstructorResult(targetClass = NativeDto.class,
+                columns = {
+                        @ColumnResult(name = "ITEM_ID", type = Integer.class),
+                        @ColumnResult(name = "ITEM_NAME", type = String.class)
+                }))
+public class NativeEntity {
+
+    public static final String QUERY_ENTITY = "Jpa32NativeQueryEntity.findEntity";
+
+    public static final String QUERY_DTO = "Jpa32NativeQueryEntity.findDto";
+
+    public static final String QUERY_COLUMN = "Jpa32NativeQueryEntity.findName";
+
+    public static final String MAPPING_DTO = "Jpa32NativeQueryDtoMapping";
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public NativeEntity() {
+    }
+
+    public NativeEntity(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.query;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".QueryBook"};
+        return createDeploymentJar("jpa_jpa32_query.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests the Jakarta Persistence 3.2 JPQL grammar change that makes
+     * identification variable declarations optional for simple queries. The test
+     * verifies that an entity name may be used directly in the {@code FROM}
+     * clause and filtered without an explicit alias.
+     */
+    @Test
+    public void jpqlOptionalClausesTest() {
+        List<QueryBook> books = getEntityManager()
+                .createQuery("FROM Jpa32QueryBook WHERE title = :title", QueryBook.class)
+                .setParameter("title", "Alpha")
+                .getResultList();
+        assertEquals(1, books.size());
+        assertEquals(1, books.get(0).getId());
+    }
+
+    /**
+     * Tests the Jakarta Persistence 3.2 JPQL relaxation allowing scalar
+     * expressions in {@code ORDER BY}. The test verifies ordering by an
+     * arithmetic expression rather than a selected state field alone.
+     */
+    @Test
+    public void jpqlOrderByScalarExpressionTest() {
+        List<String> orderedTitles = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32QueryBook b ORDER BY b.quantity + 1 DESC", String.class)
+                .getResultList();
+        assertEquals("Gamma", orderedTitles.get(0));
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 JPQL numeric literal suffixes. The test
+     * verifies that {@code bi} and {@code bd} literals are parsed as
+     * {@link BigInteger} and {@link BigDecimal} values in query predicates.
+     */
+    @Test
+    public void jpqlNumericLiteralSuffixesTest() {
+        String title = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32QueryBook b "
+                        + "WHERE b.bigIntegerValue = 10bi AND b.bigDecimalValue = 2.50bd", String.class)
+                .getSingleResult();
+        assertEquals("Alpha", title);
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new QueryBook(1, "Alpha", 10, BigInteger.TEN, new BigDecimal("2.50")));
+        getEntityManager().persist(new QueryBook(2, "Beta", 20, BigInteger.valueOf(11), new BigDecimal("3.00")));
+        getEntityManager().persist(new QueryBook(3, "Gamma", 30, BigInteger.valueOf(12), new BigDecimal("4.00")));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/QueryBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/QueryBook.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.query;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Entity(name = "Jpa32QueryBook")
+@Table(name = "JPA32_QUERY_BOOK")
+public class QueryBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Column(name = "QUANTITY")
+    private Integer quantity;
+
+    @Column(name = "BIG_INTEGER_VALUE")
+    private BigInteger bigIntegerValue;
+
+    @Column(name = "BIG_DECIMAL_VALUE", precision = 10, scale = 2)
+    private BigDecimal bigDecimalValue;
+
+    public QueryBook() {
+    }
+
+    public QueryBook(Integer id, String title, Integer quantity, BigInteger bigIntegerValue,
+            BigDecimal bigDecimalValue) {
+        this.id = id;
+        this.title = title;
+        this.quantity = quantity;
+        this.bigIntegerValue = bigIntegerValue;
+        this.bigDecimalValue = bigDecimalValue;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/BookLocation.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/BookLocation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.records;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record BookLocation(String city, String shelfCode) {
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.records;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".RecordBook", packageName + ".BookLocation"};
+        return createDeploymentJar("jpa_jpa32_records.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 support for record classes as embeddables.
+     * The test verifies that an entity can persist and retrieve an embedded Java
+     * record value.
+     */
+    @Test
+    public void recordEmbeddableTest() {
+        RecordBook book = getEntityManager().find(RecordBook.class, 1);
+        assertNotNull(book);
+        assertEquals(new BookLocation("Madrid", "A1"), book.getLocation());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new RecordBook(1, "Alpha", new BookLocation("Madrid", "A1")));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/RecordBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/RecordBook.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.records;
+
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32RecordBook")
+@Table(name = "JPA32_RECORD_BOOK")
+public class RecordBook {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "TITLE")
+    private String title;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "city", column = @Column(name = "LOCATION_CITY")),
+            @AttributeOverride(name = "shelfCode", column = @Column(name = "LOCATION_SHELF_CODE"))
+    })
+    private BookLocation location;
+
+    public RecordBook() {
+    }
+
+    public RecordBook(Integer id, String title, BookLocation location) {
+        this.id = id;
+        this.title = title;
+        this.location = location;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public BookLocation getLocation() {
+        return location;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.schemamanager;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.SchemaManager;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".SchemaManagedEntity"};
+        return createDeploymentJar("jpa_jpa32_schemamanager.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        getEntityManager();
+        removeTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests the Jakarta Persistence 3.2 {@link SchemaManager} contract exposed by
+     * {@link jakarta.persistence.EntityManagerFactory#getSchemaManager()}.
+     * The test verifies that a provider can validate the mapped schema, truncate
+     * all mapped tables, drop the mapped schema objects without script generation,
+     * recreate them, and use the recreated schema for persistence operations.
+     */
+    @Test
+    public void schemaManagerCreateValidateDropAndTruncateTest() throws Exception {
+        SchemaManager schemaManager = getEntityManagerFactory().getSchemaManager();
+        assertNotNull(schemaManager);
+
+        schemaManager.validate();
+        persistEntity(1, "before-truncate");
+        assertEquals(1L, countEntities());
+
+        schemaManager.truncate();
+        getEntityManager().clear();
+        assertEquals(0L, countEntities());
+
+        schemaManager.drop(false);
+        schemaManager.create(false);
+        schemaManager.validate();
+
+        persistEntity(2, "after-create");
+        assertEquals(1L, countEntities());
+    }
+
+    private void persistEntity(Integer id, String name) {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new SchemaManagedEntity(id, name));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private long countEntities() {
+        return getEntityManager()
+                .createQuery("SELECT COUNT(e) FROM Jpa32SchemaManagedEntity e", Long.class)
+                .getSingleResult();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/SchemaManagedEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/SchemaManagedEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.schemamanager;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32SchemaManagedEntity")
+@Table(name = "JPA32_SCHEMA_ITEM")
+public class SchemaManagedEntity {
+
+    @Id
+    private Integer id;
+
+    private String name;
+
+    public SchemaManagedEntity() {
+    }
+
+    public SchemaManagedEntity(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.singleresult;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".SingleResultBook"};
+        return createDeploymentJar("jpa_jpa32_singleresult.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests the Jakarta Persistence 3.2
+     * {@link TypedQuery#getSingleResultOrNull()} method. The test verifies that
+     * the method returns the single selected value or entity when one row
+     * matches and returns {@code null} when no row matches.
+     */
+    @Test
+    public void typedQueryGetSingleResultOrNullTest() {
+        TypedQuery<String> queryWithResult = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32SingleResultBook b WHERE b.id = :id", String.class)
+                .setParameter("id", 1);
+        assertEquals("Alpha", queryWithResult.getSingleResultOrNull());
+
+        TypedQuery<String> queryWithoutResult = getEntityManager()
+                .createQuery("SELECT b.title FROM Jpa32SingleResultBook b WHERE b.id = :id", String.class)
+                .setParameter("id", 99);
+        assertNull(queryWithoutResult.getSingleResultOrNull());
+
+        TypedQuery<SingleResultBook> queryWithEntityResult = getEntityManager()
+                .createQuery("SELECT b FROM Jpa32SingleResultBook b WHERE b.id = :id", SingleResultBook.class)
+                .setParameter("id", 1);
+        assertEquals("Alpha", queryWithEntityResult.getSingleResultOrNull().getTitle());
+
+        TypedQuery<SingleResultBook> queryWithoutEntityResult = getEntityManager()
+                .createQuery("SELECT b FROM Jpa32SingleResultBook b WHERE b.id = :id", SingleResultBook.class)
+                .setParameter("id", 99);
+        assertNull(queryWithoutEntityResult.getSingleResultOrNull());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new SingleResultBook(1, "Alpha"));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/SingleResultBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/SingleResultBook.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.singleresult;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32SingleResultBook")
+@Table(name = "JPA32_SINGLE_BOOK")
+public class SingleResultBook {
+
+    @Id
+    private Integer id;
+
+    private String title;
+
+    public SingleResultBook() {
+    }
+
+    public SingleResultBook(Integer id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.statictype;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {
+                packageName + ".StaticTypes",
+                StaticTypes.StaticEmbeddable.class.getName(),
+                StaticTypes.StaticEntity.class.getName()
+        };
+        return createDeploymentJar("jpa_jpa32_statictype.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 support for static nested persistent types.
+     * The test verifies that a static nested entity and a static nested
+     * embeddable can be managed and read back.
+     */
+    @Test
+    public void staticInnerEntityAndEmbeddableTest() {
+        StaticTypes.StaticEntity entity =
+                getEntityManager().find(StaticTypes.StaticEntity.class, 1);
+        assertNotNull(entity);
+        assertEquals("static-code", entity.getEmbedded().getCode());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new StaticTypes.StaticEntity(1,
+                new StaticTypes.StaticEmbeddable("static-code")));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/StaticTypes.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/StaticTypes.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.statictype;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+public final class StaticTypes {
+
+    private StaticTypes() {
+    }
+
+    @Embeddable
+    public static class StaticEmbeddable {
+
+        @Column(name = "EMBEDDED_CODE")
+        private String code;
+
+        public StaticEmbeddable() {
+        }
+
+        public StaticEmbeddable(String code) {
+            this.code = code;
+        }
+
+        public String getCode() {
+            return code;
+        }
+    }
+
+    @Entity(name = "Jpa32StaticEntity")
+    @Table(name = "JPA32_STATIC_ENTITY")
+    public static class StaticEntity {
+
+        @Id
+        @Column(name = "ID")
+        private Integer id;
+
+        @Embedded
+        private StaticEmbeddable embedded;
+
+        public StaticEntity() {
+        }
+
+        public StaticEntity(Integer id, StaticEmbeddable embedded) {
+            this.id = id;
+            this.embedded = embedded;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public StaticEmbeddable getEmbedded() {
+            return embedded;
+        }
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.transaction;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".TransactionEntity"};
+        return createDeploymentJar("jpa_jpa32_transaction.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 transaction timeout accessors. The test
+     * verifies that an {@link EntityTransaction} timeout can be set, read back,
+     * and cleared by setting it to {@code null}.
+     */
+    @Test
+    public void entityTransactionTimeoutTest() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.setTimeout(9);
+        assertEquals(9, transaction.getTimeout());
+        transaction.setTimeout(null);
+        assertNull(transaction.getTimeout());
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/TransactionEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/TransactionEntity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.transaction;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity(name = "Jpa32TransactionEntity")
+@Table(name = "JPA32_TRANSACTION_ENTITY")
+public class TransactionEntity {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    public TransactionEntity() {
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.uuid;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".UuidPrePersistEntity"};
+        return createDeploymentJar("jpa_jpa32_uuid.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 UUID identifier timing. The test verifies
+     * that a generated UUID primary key is assigned before {@code @PrePersist}
+     * callbacks run, making the generated identifier visible to the callback.
+     */
+    @Test
+    public void uuidGeneratedIdAvailableInPrePersistTest() {
+        UuidPrePersistEntity.resetPrePersistId();
+        UuidPrePersistEntity entity = new UuidPrePersistEntity("uuid");
+
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(entity);
+        getEntityManager().flush();
+        assertNotNull(entity.getId());
+        assertEquals(entity.getId(), UuidPrePersistEntity.getPrePersistId());
+        transaction.commit();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/UuidPrePersistEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/UuidPrePersistEntity.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.uuid;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+@Entity(name = "Jpa32UuidPrePersistEntity")
+@Table(name = "JPA32_UUID_PRE_PERSIST_ENTITY")
+public class UuidPrePersistEntity {
+
+    private static volatile UUID prePersistId;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "ID")
+    private UUID id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    public UuidPrePersistEntity() {
+    }
+
+    public UuidPrePersistEntity(String name) {
+        this.name = name;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        prePersistId = id;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public static UUID getPrePersistId() {
+        return prePersistId;
+    }
+
+    public static void resetPrePersistId() {
+        prePersistId = null;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.version;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {
+                packageName + ".LocalDateTimeVersionEntity",
+                packageName + ".InstantVersionEntity"
+        };
+        return createDeploymentJar("jpa_jpa32_version.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 version attribute type additions. The test
+     * verifies that {@code LocalDateTime} and {@code Instant} version attributes
+     * are accepted and populated for versioned entities.
+     */
+    @Test
+    public void localDateTimeAndInstantVersionTypesTest() {
+        LocalDateTimeVersionEntity localDateTimeVersionEntity =
+                getEntityManager().find(LocalDateTimeVersionEntity.class, 1);
+        assertNotNull(localDateTimeVersionEntity);
+        assertNotNull(localDateTimeVersionEntity.getVersion());
+        assertEquals(VersionTestData.FIXED_INSTANT, localDateTimeVersionEntity.getUpdatedAt());
+
+        InstantVersionEntity instantVersionEntity =
+                getEntityManager().find(InstantVersionEntity.class, 1);
+        assertNotNull(instantVersionEntity);
+        assertNotNull(instantVersionEntity.getVersion());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new LocalDateTimeVersionEntity(1, "local-date-time",
+                VersionTestData.FIXED_INSTANT));
+        getEntityManager().persist(new InstantVersionEntity(1, "instant"));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/InstantVersionEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/InstantVersionEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.version;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+
+@Entity(name = "Jpa32InstantVersionEntity")
+@Table(name = "JPA32_INSTANT_VERSION_ENTITY")
+public class InstantVersionEntity {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @Version
+    @Column(name = "VERSION_INSTANT", secondPrecision = 3)
+    private Instant version;
+
+    public InstantVersionEntity() {
+    }
+
+    public InstantVersionEntity(Integer id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Instant getVersion() {
+        return version;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/LocalDateTimeVersionEntity.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/LocalDateTimeVersionEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.version;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+@Entity(name = "Jpa32LocalDateTimeVersionEntity")
+@Table(name = "JPA32_LOCAL_DATE_TIME_VERSION")
+public class LocalDateTimeVersionEntity {
+
+    @Id
+    @Column(name = "ID")
+    private Integer id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @Version
+    @Column(name = "VERSION_TIME", secondPrecision = 3)
+    private LocalDateTime version;
+
+    @Column(name = "UPDATED_AT", secondPrecision = 3)
+    private Instant updatedAt;
+
+    public LocalDateTimeVersionEntity() {
+    }
+
+    public LocalDateTimeVersionEntity(Integer id, String name, Instant updatedAt) {
+        this.id = id;
+        this.name = name;
+        this.updatedAt = updatedAt;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDateTime getVersion() {
+        return version;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/VersionTestData.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/VersionTestData.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.version;
+
+import java.time.Instant;
+
+final class VersionTestData {
+
+    static final Instant FIXED_INSTANT = Instant.parse("2026-01-01T10:15:30Z");
+
+    private VersionTestData() {
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.year;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.EntityTransaction;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Year;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class Client extends PMClientBase {
+
+    public JavaArchive createDeployment() throws Exception {
+        String packageName = Client.class.getPackageName();
+        String[] classes = {packageName + ".YearBook"};
+        return createDeploymentJar("jpa_jpa32_year.jar", packageName, classes);
+    }
+
+    @BeforeEach
+    public void setup() throws Exception {
+        super.setup();
+        createDeployment();
+        removeTestData();
+        createTestData();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        try {
+            removeTestData();
+        } finally {
+            try {
+                super.cleanup();
+            } finally {
+                removeTestJarFromCP();
+            }
+        }
+    }
+
+    /**
+     * Tests Jakarta Persistence 3.2 basic type support for {@link Year}.
+     * The test verifies that a {@code Year} attribute can be persisted,
+     * retrieved by identifier, and used as a query parameter.
+     */
+    @Test
+    public void yearBasicTypeTest() {
+        YearBook book = getEntityManager().find(YearBook.class, 1);
+        assertNotNull(book);
+        assertEquals(Year.of(2026), book.getPublicationYear());
+
+        YearBook queried = getEntityManager()
+                .createQuery("SELECT b FROM Jpa32YearBook b WHERE b.publicationYear = :year", YearBook.class)
+                .setParameter("year", Year.of(2026))
+                .getSingleResult();
+        assertEquals(1, queried.getId());
+    }
+
+    private void createTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        transaction.begin();
+        getEntityManager().persist(new YearBook(1, "Year Book", Year.of(2026)));
+        transaction.commit();
+        getEntityManager().clear();
+    }
+
+    private void removeTestData() {
+        EntityTransaction transaction = getEntityTransaction();
+        if (transaction.isActive()) {
+            transaction.rollback();
+        }
+        getEntityManagerFactory().getSchemaManager().truncate();
+        getEntityManager().clear();
+    }
+}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/YearBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/YearBook.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.jpa32.year;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.Year;
+
+@Entity(name = "Jpa32YearBook")
+@Table(name = "JPA32_YEAR_BOOK")
+public class YearBook {
+
+    @Id
+    private Integer id;
+
+    private String title;
+
+    private Year publicationYear;
+
+    public YearBook() {
+    }
+
+    public YearBook(Integer id, String title, Year publicationYear) {
+        this.id = id;
+        this.title = title;
+        this.publicationYear = publicationYear;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public Year getPublicationYear() {
+        return publicationYear;
+    }
+}


### PR DESCRIPTION
Some things we added in 3.2 never had TCK tests. This PR rectifies that.