### PR TITLE
fix use of unconstrained type parameter in Expression.selectCase

### DIFF
--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaBuilder.java
@@ -1910,16 +1910,26 @@ public interface CriteriaBuilder {
 		 */
 		Expression<R> otherwise(Expression<? extends R> result);
 	}
-	
+
+    /**
+     * Create a simple case expression.
+     * @param expression  to be tested against the case conditions
+     * @param type the type of the result of the case expression
+     * @return simple case expression
+     */
+    <C, R> SimpleCase<C,R> selectCase(Expression<? extends C> expression, Class<R> type);
+
     /**
      * Create a simple case expression.
      * @param expression  to be tested against the case conditions
      * @param <C> the type of the case expression
      * @param <R> the result type of the case expression
      * @return simple case expression
+     * @deprecated This operation declares an unconstrained type variable.
+     *             Use {@link #selectCase(Expression,Class)} instead.
      */
+    @Deprecated(since = "4.0")
     <C, R> SimpleCase<C,R> selectCase(Expression<? extends C> expression);
-
 
     /**
      * Interface used to build general case expressions.
@@ -1960,12 +1970,22 @@ public interface CriteriaBuilder {
 		 */
 		Expression<R> otherwise(Expression<? extends R> result);
 	}
-	
+
+    /**
+     * Create a general case expression.
+     * @param type the type of the result of the case expression
+     * @return general case expression
+     */
+    <R> Case<R> selectCase(Class<R> type);
+
     /**
      * Create a general case expression.
      * @param <R> the result type of the case expression
      * @return general case expression
+     * @deprecated This operation declares an unconstrained type variable.
+     *             Use {@link #selectCase(Class)} instead.
      */
+    @Deprecated(since = "4.0")
     <R> Case<R> selectCase();
 
     /**

--- a/api/src/main/java/jakarta/persistence/criteria/Expression.java
+++ b/api/src/main/java/jakarta/persistence/criteria/Expression.java
@@ -198,11 +198,12 @@ public interface Expression<T> extends Selection<T> {
 
     /**
      * Create a simple case expression to test against this expression.
+     * @param type the type of the result of the case expression
      * @param <R> the result type of the case expression
      * @return simple case expression
      * @since 4.0
      */
-    <R> SimpleCase<T,R> selectCase();
+    <R> SimpleCase<T,R> selectCase(Class<R> type);
 
     //collection operations:
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
@@ -252,7 +252,7 @@ public class Client extends PMClientBase {
         CriteriaQuery<String> label = builder.createQuery(String.class);
         Root<SpecializedBook> book = label.from(SpecializedBook.class);
         TextExpression title = book.get(SpecializedBook_.title);
-        label.select(title.<String>selectCase()
+        label.select(title.selectCase(String.class)
                         .when("Alpha", title.nullif("Alpha").coalesce("first"))
                         .otherwise("other"))
                 .where(title.equalTo("Alpha"));


### PR DESCRIPTION
it's easier to specify the type as an argument than as a type argument