### PR TITLE
Document requirement to update version value of entity

### DIFF
--- a/api/src/main/java/jakarta/persistence/Version.java
+++ b/api/src/main/java/jakarta/persistence/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2026 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -35,6 +35,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * or timestamp held in the database changes between reading the
  * state of an entity instance and attempting to update or delete
  * the state of the instance.
+ *
+ * <p>The entity version must be updated by the persistence provider
+ * each time the state of an entity instance is written to the database.
  *
  * <p>The version attribute must be of one of the following basic
  * types: {@code int}, {@link Integer}, {@code short}, {@link Short},


### PR DESCRIPTION
Jakarta Data repositories that use EntityAgent need to know whether the version is automatically updated when invoking update/upsert/insert methods because the contract for the respective Jakarta Data `@Update`/`@Save`/`@Insert` repository methods requires returning an entity with the version updated.  The most convenient behavior, and what Hibernate appears to already be doing in its 8.0.0.0-Alpha1, is to update the version on the given entity.  This PR adds this as a requirement to Javadoc.

It was later identified that the Jakarta Persistence spec already documents the requirement, so this PR has been repurposed to also mention it in the Javadoc that application developers are more likely to see.