### PR TITLE
move section on derivation of constraints for Validation annotations

### DIFF
--- a/api/src/main/java/jakarta/persistence/Statement.java
+++ b/api/src/main/java/jakarta/persistence/Statement.java
@@ -452,7 +452,7 @@ public interface Statement extends Query {
 
     /**
      * Get the {@linkplain Option options} influencing execution of
-     * this statement.  The returned set includes options set via
+     * this statement. The returned set includes options set via
      * {@link #addOption}, along with options specified via
      * {@link #setTimeout} or {@link #setQueryFlushMode}. Mutation of
      * the returned set does not affect the options of the statement.

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -2247,7 +2247,8 @@ and <<a2374,the integration is enabled>>, the persistence provider must:
 ==== Configuring the Jakarta Validation provider
 
 The persistence provider is not expected to implement Jakarta Validation.
-Instead, and instance of `jakarta.validation.ValidatorFactory` must be made available to the provider.
+Instead, an instance of `jakarta.validation.ValidatorFactory` must be made
+available to the provider.
 
 ===== Providing the ValidatorFactory [[a2394]]
 

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -2244,11 +2244,14 @@ and <<a2374,the integration is enabled>>, the persistence provider must:
   The provider must utilize specific Jakarta Validation constraint metadata to derive persistent attribute characteristics
   (such as nullability, length, precision) and database constraints for the purpose of DDL schema generation.
 
-==== Configuring Jakarta Validation provider
+==== Configuring the Jakarta Validation provider
+
+The persistence provider is not expected to implement Jakarta Validation.
+Instead, and instance of `jakarta.validation.ValidatorFactory` must be made available to the provider.
 
 ===== Providing the ValidatorFactory [[a2394]]
 
-In Jakarta EE environments, a `jakarta.validation.ValidatorFactory`
+In Jakarta EE environments, a `ValidatorFactory`
 instance is made available by the Jakarta EE container. The container
 is responsible for passing this validator factory to the persistence
 provider via a map, which is passed as the second argument to
@@ -2397,172 +2400,6 @@ from a `jakarta.validation.ValidatorFactory` instance by calling
 `validatorFactory.usingContext().traversableResolver(tr).getValidator()`,
 where `tr` is the resolver.
 
-==== Derivation of schema metadata from Jakarta Validation constraints [[schema-generation-from-jakarta-validation-constraints]]
-
-Certain Jakarta Validation constraints can override
-the persistent attribute metadata and influence the
-schema generation.
-
-The following list describes how constraints affect
-the persistent attributes they are applied to:
-
-`jakarta.validation.constraints.NotNull`::
-This constraint is treated as a way to specify that
-the column mapped by the attribute is not nullable.
-Influence on metadata:::
-Overrides the `nullable` attribute and sets it to `false`.
-Influence on DDL:::
-Adds a `NOT NULL` constraint to the column.
-
-`jakarta.validation.constraints.NotBlank`::
-Similar to `jakarta.validation.constraints.NotNull`
-this constraint is treated as a way to specify that
-the column mapped by the attribute is not nullable.
-With difference being that `@NotBlank` constraint
-is applicable to fewer types compared to
-`@NotNull` constraint.
-Influence on metadata:::
-Overrides the `nullable` attribute and sets it to `false`.
-Influence on DDL:::
-Adds a `NOT NULL` constraint to the column.
-
-`jakarta.validation.constraints.NotEmpty`::
-Same as `jakarta.validation.constraints.NotNull`
-this constraint is treated as a way to specify that
-the column mapped by the attribute is not nullable.
-With difference being that `@NotEmpty` constraint
-is applicable to fewer types compared to
-`@NotNull` constraint.
-Influence on metadata:::
-Overrides the `nullable` attribute and sets it to `false`.
-Influence on DDL:::
-Adds a `NOT NULL` constraint to the column.
-
-`jakarta.validation.constraints.Digits`::
-This constraint is treated as a way to specify
-the precision and scale of a numeric column.
-Influence on metadata:::
-Sets the `precision` attribute to the sum of
-`integer` and `fraction`, and the `scale`
-attribute to `fraction`.
-Influence on DDL:::
-Defines the numeric type precision and scale,
-e.g. `DECIMAL(precision, scale)`.
-
-`jakarta.validation.constraints.Size`::
-If this constraint specifies the maximum value,
-e.g. `@Size(max = {someValue})`, then it is treated
-as a way to specify the length of the column mapped
-by the attribute, i.e. `length={someValue}`.
-Influence on metadata:::
-Sets the `length` attribute to `{someValue}`.
-Influence on DDL:::
-Defines the column length, e.g. `VARCHAR({someValue})`.
-
-`jakarta.validation.constraints.Min`::
-This constraint is treated as a way to specify
-a check constraint on a numeric column.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g.
-`CHECK (column_name >= value)`, where `value`
-is the value defined in the constraint.
-
-`jakarta.validation.constraints.Max`::
-This constraint is treated as a way to specify
-a check constraint on a numeric column.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g.
-`CHECK (column_name \<= value)`, where `value`
-is the value defined in the constraint.
-
-`jakarta.validation.constraints.DecimalMin`::
-This constraint is treated as a way to specify
-a check constraint on a numeric column.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g.
-`CHECK (column_name >= value)` if `inclusive`
-is `true` (default), or `CHECK (column_name > value)`
-otherwise.
-
-`jakarta.validation.constraints.DecimalMax`::
-This constraint is treated as a way to specify
-a check constraint on a numeric column.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g.
-`CHECK (column_name \<= value)` if `inclusive`
-is `true` (default), or `CHECK (column_name < value)`
-otherwise.
-
-`jakarta.validation.constraints.Negative`::
-This constraint is handled the same as
-`jakarta.validation.constraints.Max(-1)` for integral types and
-`jakarta.validation.constraints.DecimalMax(value = BigDecimal.ZERO, inclusive = false)`
-for decimal types.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g. `CHECK (column_name < 0)`.
-
-`jakarta.validation.constraints.NegativeOrZero`::
-This constraint is handled the same as
-`jakarta.validation.constraints.Max(0)` for integral types and
-`jakarta.validation.constraints.DecimalMax(value = BigDecimal.ZERO)`
-for decimal types.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g. `CHECK (column_name \<= 0)`.
-
-`jakarta.validation.constraints.Positive`::
-This constraint is handled the same as
-`jakarta.validation.constraints.Min(1)` for integral types and
-`jakarta.validation.constraints.DecimalMin(value = BigDecimal.ZERO, inclusive = false)`
-for decimal types.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g. `CHECK (column_name > 0)`.
-
-`jakarta.validation.constraints.PositiveOrZero`::
-This constraint is handled the same as
-`jakarta.validation.constraints.Min(0)` for integral types and
-`jakarta.validation.constraints.DecimalMin(value = BigDecimal.ZERO)`
-for decimal types.
-Influence on metadata:::
-None.
-Influence on DDL:::
-Adds a check constraint to the column, e.g. `CHECK (column_name >= 0)`.
-
-Persistence providers must comply with the following precedence
-and resolution rules:
-
-* Jakarta Validation constraint metadata takes precedence over
-Jakarta Persistence.
-* Jakarta Validation constraint metadata takes precedence over
-`@jakarta.annotation.Nonnull`.
-* When multiple Jakarta Validation constraints apply to the same
-attribute, the most restrictive constraint must be applied.
-* It is up to the persistence provider how to process multiple
-check clauses contributed by different constraints.
-
-[NOTE]
-====
-This specification expects that only constraints that belong to the
-`jakarta.validation.groups.Default` validation group are considered
-for this additional metadata contribution.
-
-Persistent providers may have a way to override this expectation
-and allow users to specify a different validation group or groups
-to be considered for DDL operations.
-====
 
 === Entity Graphs [[a2397]]
 

--- a/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
+++ b/spec/src/main/asciidoc/ch11-metadata-for-or-mapping.adoc
@@ -6710,3 +6710,170 @@ public class EmploymentPeriod implements Serializable {
     }
 }
 ----
+
+=== Derivation of schema metadata from Jakarta Validation constraints [[schema-generation-from-jakarta-validation-constraints]]
+
+Certain Jakarta Validation constraints can override
+the persistent attribute metadata and influence the
+schema generation.
+
+The following list describes how constraints affect
+the persistent attributes they are applied to:
+
+`jakarta.validation.constraints.NotNull`::
+This constraint is treated as a way to specify that
+the column mapped by the attribute is not nullable.
+Influence on metadata:::
+Overrides the `nullable` attribute and sets it to `false`.
+Influence on DDL:::
+Adds a `NOT NULL` constraint to the column.
+
+`jakarta.validation.constraints.NotBlank`::
+Similar to `jakarta.validation.constraints.NotNull`
+this constraint is treated as a way to specify that
+the column mapped by the attribute is not nullable.
+With difference being that `@NotBlank` constraint
+is applicable to fewer types compared to
+`@NotNull` constraint.
+Influence on metadata:::
+Overrides the `nullable` attribute and sets it to `false`.
+Influence on DDL:::
+Adds a `NOT NULL` constraint to the column.
+
+`jakarta.validation.constraints.NotEmpty`::
+Same as `jakarta.validation.constraints.NotNull`
+this constraint is treated as a way to specify that
+the column mapped by the attribute is not nullable.
+With difference being that `@NotEmpty` constraint
+is applicable to fewer types compared to
+`@NotNull` constraint.
+Influence on metadata:::
+Overrides the `nullable` attribute and sets it to `false`.
+Influence on DDL:::
+Adds a `NOT NULL` constraint to the column.
+
+`jakarta.validation.constraints.Digits`::
+This constraint is treated as a way to specify
+the precision and scale of a numeric column.
+Influence on metadata:::
+Sets the `precision` attribute to the sum of
+`integer` and `fraction`, and the `scale`
+attribute to `fraction`.
+Influence on DDL:::
+Defines the numeric type precision and scale,
+e.g. `DECIMAL(precision, scale)`.
+
+`jakarta.validation.constraints.Size`::
+If this constraint specifies the maximum value,
+e.g. `@Size(max = {someValue})`, then it is treated
+as a way to specify the length of the column mapped
+by the attribute, i.e. `length={someValue}`.
+Influence on metadata:::
+Sets the `length` attribute to `{someValue}`.
+Influence on DDL:::
+Defines the column length, e.g. `VARCHAR({someValue})`.
+
+`jakarta.validation.constraints.Min`::
+This constraint is treated as a way to specify
+a check constraint on a numeric column.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g.
+`CHECK (column_name >= value)`, where `value`
+is the value defined in the constraint.
+
+`jakarta.validation.constraints.Max`::
+This constraint is treated as a way to specify
+a check constraint on a numeric column.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g.
+`CHECK (column_name \<= value)`, where `value`
+is the value defined in the constraint.
+
+`jakarta.validation.constraints.DecimalMin`::
+This constraint is treated as a way to specify
+a check constraint on a numeric column.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g.
+`CHECK (column_name >= value)` if `inclusive`
+is `true` (default), or `CHECK (column_name > value)`
+otherwise.
+
+`jakarta.validation.constraints.DecimalMax`::
+This constraint is treated as a way to specify
+a check constraint on a numeric column.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g.
+`CHECK (column_name \<= value)` if `inclusive`
+is `true` (default), or `CHECK (column_name < value)`
+otherwise.
+
+`jakarta.validation.constraints.Negative`::
+This constraint is handled the same as
+`jakarta.validation.constraints.Max(-1)` for integral types and
+`jakarta.validation.constraints.DecimalMax(value = BigDecimal.ZERO, inclusive = false)`
+for decimal types.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g. `CHECK (column_name < 0)`.
+
+`jakarta.validation.constraints.NegativeOrZero`::
+This constraint is handled the same as
+`jakarta.validation.constraints.Max(0)` for integral types and
+`jakarta.validation.constraints.DecimalMax(value = BigDecimal.ZERO)`
+for decimal types.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g. `CHECK (column_name \<= 0)`.
+
+`jakarta.validation.constraints.Positive`::
+This constraint is handled the same as
+`jakarta.validation.constraints.Min(1)` for integral types and
+`jakarta.validation.constraints.DecimalMin(value = BigDecimal.ZERO, inclusive = false)`
+for decimal types.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g. `CHECK (column_name > 0)`.
+
+`jakarta.validation.constraints.PositiveOrZero`::
+This constraint is handled the same as
+`jakarta.validation.constraints.Min(0)` for integral types and
+`jakarta.validation.constraints.DecimalMin(value = BigDecimal.ZERO)`
+for decimal types.
+Influence on metadata:::
+None.
+Influence on DDL:::
+Adds a check constraint to the column, e.g. `CHECK (column_name >= 0)`.
+
+Persistence providers must comply with the following precedence
+and resolution rules:
+
+* Jakarta Validation constraint metadata takes precedence over
+Jakarta Persistence.
+* Jakarta Validation constraint metadata takes precedence over
+`@jakarta.annotation.Nonnull`.
+* When multiple Jakarta Validation constraints apply to the same
+attribute, the most restrictive constraint must be applied.
+* It is up to the persistence provider how to process multiple
+check clauses contributed by different constraints.
+
+[NOTE]
+====
+This specification expects that only constraints that belong to the
+`jakarta.validation.groups.Default` validation group are considered
+for this additional metadata contribution.
+
+Persistent providers may have a way to override this expectation
+and allow users to specify a different validation group or groups
+to be considered for DDL operations.
+====


### PR DESCRIPTION
We don't want to further bloat-out the Entity Operations chapter.