### PR TITLE
rework semantics of EntityExistsException

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityAgent.java
+++ b/api/src/main/java/jakarta/persistence/EntityAgent.java
@@ -107,6 +107,11 @@ import java.util.function.Function;
  * and since the entities themselves are detached, modifications to
  * the entities are never automatically detected and made persistent.
  *
+ * <p>An exception thrown by a method of an {@code EntityAgent},
+ * or by a method of an instance of {@link Query} obtained from
+ * an {@code EntityAgent}, is considered recoverable and does not
+ * usually cause the active transaction to be marked for rollback.
+ *
  * @since 4.0
  *
  * @see EntityManager

--- a/api/src/main/java/jakarta/persistence/EntityAgent.java
+++ b/api/src/main/java/jakarta/persistence/EntityAgent.java
@@ -136,10 +136,8 @@ public interface EntityAgent extends EntityHandler {
      *
      * @throws IllegalArgumentException if the given instance is
      *         determined to not be new or removed
-     * @throws EntityExistsException if the given entity has an
-     *         identifier assigned by the application, and a
-     *         record with the assigned identifier already exists
-     *         in the database
+     * @throws EntityExistsException if any kind of uniqueness
+     *         constraint is violated
      * @throws PersistenceException if a record could not be
      *         inserted in the database
      */
@@ -155,10 +153,8 @@ public interface EntityAgent extends EntityHandler {
      *
      * @throws IllegalArgumentException if one of the given
      *         instances is determined to not be new or removed
-     * @throws EntityExistsException if one of the given entities
-     *         has an identifier assigned by the application, and
-     *         a record with the assigned identifier already exists
-     *         in the database
+     * @throws EntityExistsException if any kind of uniqueness
+     *         constraint is violated
      * @throws PersistenceException if a record could not be
      *         inserted in the database
      *

--- a/api/src/main/java/jakarta/persistence/EntityExistsException.java
+++ b/api/src/main/java/jakarta/persistence/EntityExistsException.java
@@ -22,17 +22,22 @@ package jakarta.persistence;
  * <ul>
  * <li>a detached instance of an entity type is passed to
  *     {@link EntityManager#persist(Object)}, or
- * <li>an instance of an entity type with an identifier already
- *     assigned by the application is passed to
- *     {@link EntityAgent#insert(Object)}, and a record with the
- *     assigned identifier value already exists in the database.
+ * <li>any kind of uniqueness constraint is violated when an
+ *     entity is inserted in the database.
  * </ul>
  *
- * <p> If a detached instance is passed to the persist operation,
- * an {@code EntityExistsException} may be immediately thrown by
- * {@code persist()}, or the {@code EntityExistsException} or
- * another {@link PersistenceException} may be thrown at flush or
- * commit time.
+ * <p> The persistence provider is always permitted to postpone
+ * an {@code EntityExistsException} until execution of the
+ * resulting database insert operation. If a detached instance
+ * is passed to the persist operation, either:
+ * <ul>
+ * <li>an {@code EntityExistsException} is immediately thrown
+ *     by {@code persist()}, or
+ * <li>an {@code EntityExistsException} or some other subtype
+ *     of {@link PersistenceException} is thrown when the
+ *     persistence context is flushed or when the transaction
+ *     commits.
+ * </ul>
  *
  * <p> If an {@code EntityExistsException} is thrown by an
  * {@link EntityManager} with a persistence context joined to

--- a/api/src/main/java/jakarta/persistence/EntityHandler.java
+++ b/api/src/main/java/jakarta/persistence/EntityHandler.java
@@ -154,6 +154,18 @@ public interface EntityHandler extends AutoCloseable {
      *         unit, or if the given identifier is not a
      *         non-null instance of the identifier type of the
      *         given entity class
+     * @throws TransactionRequiredException if any lock mode
+     *         other than {@link LockModeType#NONE NONE} is
+     *         specified and there is no transaction
+     *         associated with this handler
+     * @throws OptimisticLockException if an optimistic version
+     *         check fails
+     * @throws PessimisticLockException if a pessimistic lock
+     *         could not be obtained and the transaction is
+     *         rolled back
+     * @throws LockTimeoutException if a pessimistic lock
+     *         could not be obtained and only the statement
+     *         is rolled back
      * @throws EntityNotFoundException if no record with the
      *         given identifier exists in the database
      * @throws PersistenceException if a given
@@ -198,6 +210,18 @@ public interface EntityHandler extends AutoCloseable {
      *         unit, or if the given identifier is not a
      *         non-null instance of the identifier type of the
      *         given entity class
+     * @throws TransactionRequiredException if any lock mode
+     *         other than {@link LockModeType#NONE NONE} is
+     *         specified and there is no transaction
+     *         associated with this handler
+     * @throws OptimisticLockException if an optimistic version
+     *         check fails
+     * @throws PessimisticLockException if a pessimistic lock
+     *         could not be obtained and the transaction is
+     *         rolled back
+     * @throws LockTimeoutException if a pessimistic lock
+     *         could not be obtained and only the statement
+     *         is rolled back
      * @throws EntityNotFoundException if no record with the
      *         given identifier exists in the database
      * @throws PersistenceException if a given
@@ -242,6 +266,18 @@ public interface EntityHandler extends AutoCloseable {
      *         unit, or if one of the given identifiers is not
      *         a non-null instance of the identifier type of
      *         the given entity class
+     * @throws TransactionRequiredException if any lock mode
+     *         other than {@link LockModeType#NONE NONE} is
+     *         specified and there is no transaction
+     *         associated with this handler
+     * @throws OptimisticLockException if an optimistic version
+     *         check fails
+     * @throws PessimisticLockException if a pessimistic lock
+     *         could not be obtained and the transaction is
+     *         rolled back
+     * @throws LockTimeoutException if a pessimistic lock
+     *         could not be obtained and only the statement
+     *         is rolled back
      * @throws EntityNotFoundException if no record exists in
      *         the database for one of the given identifiers
      * @throws PersistenceException if a given
@@ -287,6 +323,18 @@ public interface EntityHandler extends AutoCloseable {
      *         unit, or if one of the given identifiers is not
      *         a non-null instance of the identifier type of
      *         the given entity class
+     * @throws TransactionRequiredException if any lock mode
+     *         other than {@link LockModeType#NONE NONE} is
+     *         specified and there is no transaction
+     *         associated with this handler
+     * @throws OptimisticLockException if an optimistic version
+     *         check fails
+     * @throws PessimisticLockException if a pessimistic lock
+     *         could not be obtained and the transaction is
+     *         rolled back
+     * @throws LockTimeoutException if a pessimistic lock
+     *         could not be obtained and only the statement
+     *         is rolled back
      * @throws EntityNotFoundException if no record exists in
      *         the database for one of the given identifiers
      * @throws PersistenceException if a given

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -227,11 +227,12 @@ public interface EntityManager extends EntityHandler {
      * to this persistence context and has not been marked for removal,
      * it is itself ignored, but the operation still cascades.
      * @param entity  a new, managed, or removed entity instance
-     * @throws EntityExistsException if the given entity is detached
-     * (if the entity is detached, the {@code EntityExistsException}
-     * may be thrown when the persist operation is invoked, or the
-     * {@code EntityExistsException} or another {@code PersistenceException}
-     * may be thrown at flush or commit time)
+     * @throws EntityExistsException if the given entity is detached; if
+     *         the entity is detached, either an {@code EntityExistsException}
+     *         is thrown immediately, or an {@code EntityExistsException}
+     *         or some other subtype of {@code PersistenceException} is
+     *         thrown when the persistence context is flushed or when the
+     *         transaction commits
      * @throws IllegalArgumentException if the given instance is not an
      *         entity
      * @throws TransactionRequiredException if there is no transaction
@@ -439,6 +440,9 @@ public interface EntityManager extends EntityHandler {
      * @throws TransactionRequiredException if there is
      *        no transaction or if the entity manager has not been
      *        joined to the current transaction
+     * @throws EntityExistsException if any kind of uniqueness
+     *         constraint is violated by an operation which inserts
+     *         an entity in the database
      * @throws PersistenceException if the flush fails
      * @throws OptimisticLockException if an optimistic locking
      *         conflict is detected

--- a/api/src/main/java/jakarta/persistence/EntityManager.java
+++ b/api/src/main/java/jakarta/persistence/EntityManager.java
@@ -184,6 +184,12 @@ import jakarta.persistence.criteria.CriteriaStatement;
  * calling {@link #setCacheRetrieveMode(CacheRetrieveMode)} and
  * {@link #setCacheStoreMode(CacheStoreMode)}.
  *
+ * <p>An exception thrown by a method of an {@code EntityManager},
+ * or by a method of an instance of {@link Query} obtained from an
+ * {@code EntityManager}, causes the active transaction to be marked
+ * for rollback unless the exception type is explicitly designated
+ * as recoverable.
+ *
  * <p>Some operations accept one or more built-in and vendor-specific
  * options:
  * <ul>

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -329,9 +329,10 @@ is applied to `e` via cascade:
 * if `e` is a managed entity already associated with the persistence
   context, `e` itself is ignored by the persist operation;
 * if `e` is a removed entity, it becomes managed; or
-* if `e` is a detached entity, the `EntityExistsException` may be thrown
-  when the persist operation is invoked, or the `EntityExistsException`
-  or another `PersistenceException` may be thrown at flush or commit time.
+* if `e` is a detached entity, either an `EntityExistsException` is thrown
+  immediately, or an `EntityExistsException` or some other subtype of
+  `PersistenceException` is thrown when the persistence context is flushed
+  or when the transaction commits.
 * If `e` is new, managed, or removed, the persist operation is also applied
   to every entity `t` referenced by a relationship owned by `e` and annotated
   with the `cascade` element value `cascade=PERSIST` or `cascade=ALL` or
@@ -4323,15 +4324,22 @@ Thrown by the persistence provider when:
 
 - a detached instance of an entity type is passed to `persist()`,
   or
-- an instance of an entity type with an identifier assigned by
-  the application is passed to `insert()`, and a record with the
-  assigned identifier value already exists in the database.
+- any kind of uniqueness constraint is violated when an entity
+  is inserted in the database.
 
 +
-If a detached instance is passed to the persist operation, an
-`EntityExistsException` may be immediately thrown by `persist()`,
-or the `EntityExistsException` or another `PersistenceException`
-may be thrown at flush or commit time.
+The persistence provider is always permitted to postpone an
+`EntityExistsException` until execution of the resulting database
+insert operation. If a detached instance is passed to the persist
+operation, either:
+
+- an `EntityExistsException` is immediately thrown by `persist()`,
+  or
+- an `EntityExistsException` or some other subtype of
+  `PersistenceException` is thrown when the persistence context
+  is flushed or when the transaction commits.
+
++
 If thrown by an `EntityManager` with a persistence context
 joined to an active transaction, the transaction is marked for
 rollback when this exception is thrown.

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/AgentBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/AgentBook.java
@@ -16,6 +16,7 @@
 
 package ee.jakarta.tck.persistence.jpa40.entityagent;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
@@ -31,6 +32,7 @@ public class AgentBook {
     @Id
     private Integer id;
 
+    @Column(unique = true)
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
@@ -20,12 +20,11 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityAgent;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.EntityExistsException;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.OptimisticLockException;
-import jakarta.persistence.PersistenceException;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
@@ -338,6 +337,26 @@ public class Client extends PMClientBase {
     }
 
     /**
+     * Verifies EntityManager.flush() reports the specified exception type when
+     * an inserted entity violates a uniqueness constraint.
+     */
+    @Test
+    public void entityManagerFlushUniquenessViolationTest() {
+        EntityTransaction transaction = getEntityTransaction();
+        try {
+            transaction.begin();
+            getEntityManager().persist(new AgentBook(1, "duplicate title"));
+            getEntityManager().persist(new AgentBook(2, "duplicate title"));
+            assertThrows(EntityExistsException.class, () -> getEntityManager().flush());
+        } finally {
+            rollbackIfActive(transaction);
+            getEntityManager().clear();
+        }
+
+        assertEquals(0L, countBooks());
+    }
+
+    /**
      * Verifies bulk write operations and stale upsert operations report the
      * specified exception types for invalid, missing, or stale records.
      */
@@ -351,7 +370,7 @@ public class Client extends PMClientBase {
         var transaction = agent.getTransaction();
         try {
             transaction.begin();
-            assertThrows(PersistenceException.class,
+            assertThrows(EntityExistsException.class,
                     () -> agent.insertMultiple(List.of(new AgentBook(1, "duplicate bulk"))));
             rollbackIfActive(transaction);
 


### PR DESCRIPTION
The provider doesn't always know exactly why the insert failed, and so it can't be sure an `EntityExistsException` is appropriate.