### PR TITLE
add note to spec + jdoc about new vs detached

### DIFF
--- a/api/src/main/java/jakarta/persistence/Id.java
+++ b/api/src/main/java/jakarta/persistence/Id.java
@@ -78,6 +78,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * <p>The {@code @Id} annotation should never be applied to a field
  * or property of an embeddable id or id class.
  *
+ * <p>The persistence provider is permitted to use the value of the
+ * identifier and version fields or properties of an entity instance
+ * to determine whether the instance is new or detached.
+ *
  * @see Column
  * @see GeneratedValue
  * @see EmbeddedId

--- a/api/src/main/java/jakarta/persistence/Version.java
+++ b/api/src/main/java/jakarta/persistence/Version.java
@@ -74,6 +74,10 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * If the versions do not match, the persistence provider must throw an
  * {@link OptimisticLockException}.
  *
+ * <p>The persistence provider is permitted to use the value of the
+ * identifier and version fields or properties of an entity instance
+ * to determine whether the instance is new or detached.
+ *
  * @see LockModeType
  * @see PersistenceUnitUtil#getVersion(Object)
  * @see ExcludedFromVersioning

--- a/spec/src/main/asciidoc/ch03-entity-operations.adoc
+++ b/spec/src/main/asciidoc/ch03-entity-operations.adoc
@@ -592,6 +592,11 @@ A detached entity instance continues to live outside the persistence
 context in which it was persisted or retrieved. Its state does not
 remain synchronized with the database record it represents.
 
+When an entity instance is passed to an operation like `persist()`
+or `merge()`, the persistence provider is permitted to use the value
+of the identifier and version fields or properties of an entity
+instance to determine whether the instance is new or detached.
+
 ===== Detached Entities and Lazy Loading [[detached-lazy-state]]
 
 The _available_ state of a detached entity instance is the state which


### PR DESCRIPTION
This is not new, it's already implicitly and intentionally permitted by the spec.

I just want to make it explicit for the benefit of users.