### PR TITLE
consider dropping a minor requirement that's just unnecessary

### DIFF
--- a/api/src/main/java/jakarta/persistence/query/NativeQuery.java
+++ b/api/src/main/java/jakarta/persistence/query/NativeQuery.java
@@ -115,8 +115,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * mapping} may be specified by annotating the method with one or more
  * {@link jakarta.persistence.EntityResult},
  * {@link jakarta.persistence.ColumnResult}, or
- * {@link jakarta.persistence.ConstructorResult} annotations. The inferred
- * result set mapping has the same name as the query.
+ * {@link jakarta.persistence.ConstructorResult} annotations.
  * {@snippet :
  * @NativeQuery("select * from books where isbn = ?")
  * @EntityResult(entityClass = Book.class,
@@ -129,10 +128,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * row of the mapped query result set is represented as an instance of
  * {@code Object[]} whose elements are, in order:
  * <ol>
- * <li>entity results, in the order in which they are declared;
- * <li>constructor results, in the order in which they are declared;
- *     and then
- * <li>scalar results, in the order in which they are declared.
+ * <li>{@linkplain jakarta.persistence.EntityResult entity results},
+ *     in the order in which they are declared;
+ * <li>{@linkplain jakarta.persistence.ConstructorResult constructor
+ *     results}, in the order in which they are declared; and then
+ * <li>{@linkplain jakarta.persistence.ColumnResult scalar results},
+ *     in the order in which they are declared.
  * </ol>
  *
  * @since 4.0

--- a/spec/src/main/asciidoc/ch05-metamodel-api.adoc
+++ b/spec/src/main/asciidoc/ch05-metamodel-api.adoc
@@ -75,8 +75,7 @@ it belongs to the persistence unit and:
 - it is annotated with a _discoverable annotation type_, as defined in
   <<discoverable>>, or
 - it has a method annotated with one of the two static query annotations,
-  `@JakartaQuery` or `@NativeQuery`, as defined in
-  <<static-query-api>>.
+  `@JakartaQuery` or `@NativeQuery`, as defined in <<static-query-api>>.
 
 This specification does not require that the annotation processor generate
 a canonical metamodel class for a type which is declared as a managed type


### PR DESCRIPTION
We probably don't need to say that the result set mapping inferred from a `@NativeQuery` has a name or what the name is.

Note that we *do* want a third-party implementation of Jakarta Data to have the option of executing the `@NativeQuery` as a named query, so we do want to nail down the name of that query, but a named native query carries its result set mapping with it, and we don't need to say how that happens.