### PR TITLE
add additional overloads of operations accepting restriction lists

### DIFF
--- a/api/src/main/java/jakarta/persistence/criteria/CollectionJoin.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CollectionJoin.java
@@ -19,6 +19,8 @@ package jakarta.persistence.criteria;
 
 import jakarta.annotation.Nonnull;
 import java.util.Collection;
+import java.util.List;
+
 import jakarta.persistence.metamodel.CollectionAttribute;
 
 /**
@@ -42,6 +44,7 @@ public interface CollectionJoin<Z, E>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     CollectionJoin<Z, E> on(@Nonnull Expression<Boolean> restriction);
 
@@ -53,8 +56,21 @@ public interface CollectionJoin<Z, E>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     CollectionJoin<Z, E> on(@Nonnull BooleanExpression... restrictions);
+
+    /**
+     * Modify the join to restrict the result according to the
+     * specified ON condition and return the join object.
+     * Replaces the previous ON condition, if any.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified join object
+     * @since 4.0
+     */
+    @Override
+    @Nonnull
+    CollectionJoin<Z, E> on(@Nonnull List<? extends Expression<Boolean>> restrictions);
 
     /**
      * Return the metamodel representation for the collection
@@ -62,6 +78,7 @@ public interface CollectionJoin<Z, E>
      * @return metamodel type representing the {@code Collection} that is
      *         the target of the join
      */
+    @Override
     @Nonnull
     CollectionAttribute<? super Z, E> getModel();
 
@@ -72,6 +89,7 @@ public interface CollectionJoin<Z, E>
      * @return this join downcast to the given element type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends E> CollectionJoin<Z, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaDelete.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaDelete.java
@@ -18,6 +18,8 @@ package jakarta.persistence.criteria;
 
 import jakarta.annotation.Nonnull;
 
+import java.util.List;
+
 /**
  * The {@code CriteriaDelete} interface defines functionality for 
  * performing bulk delete operations using the Criteria API
@@ -57,4 +59,17 @@ public interface CriteriaDelete<T> extends CriteriaStatement<T> {
     @Nonnull
     CriteriaDelete<T> where(@Nonnull BooleanExpression... restrictions);
 
+    /**
+     * Modify the DELETE query to restrict the target of the deletion
+     * according to the conjunction of the specified restriction
+     * predicates.
+     * Replaces the previously added restriction(s), if any.
+     * If no restrictions are specified, any previously added
+     * restrictions are simply removed.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified delete query
+     * @since 4.0
+     */
+    @Nonnull
+    CriteriaDelete<T> where(@Nonnull List<? extends Expression<Boolean>> restrictions);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/CriteriaUpdate.java
+++ b/api/src/main/java/jakarta/persistence/criteria/CriteriaUpdate.java
@@ -20,6 +20,8 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.metamodel.SingularAttribute;
 
+import java.util.List;
+
 /**
  * The {@code CriteriaUpdate} interface defines functionality for
  * performing bulk update operations using the Criteria API.
@@ -123,4 +125,18 @@ public interface CriteriaUpdate<T> extends CriteriaStatement<T> {
      */
     @Nonnull
     CriteriaUpdate<T> where(@Nonnull BooleanExpression... restrictions);
+
+    /**
+     * Modify the update query to restrict the target of the
+     * update according to the conjunction of the specified
+     * restriction predicates.
+     * Replaces the previously added restriction(s), if any.
+     * If no restrictions are specified, any previously added
+     * restrictions are simply removed.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified update query
+     * @since 4.0
+     */
+    @Nonnull
+    CriteriaUpdate<T> where(@Nonnull List<? extends Expression<Boolean>> restrictions);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/From.java
+++ b/api/src/main/java/jakarta/persistence/criteria/From.java
@@ -432,6 +432,7 @@ public interface From<Z, X> extends Path<X>, FetchParent<Z, X> {
      * @return this root or join downcast to the given type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends X> From<?, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/Join.java
+++ b/api/src/main/java/jakarta/persistence/criteria/Join.java
@@ -20,6 +20,8 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.metamodel.Attribute;
 
+import java.util.List;
+
 /**
  * A join to an entity, embeddable, or basic type.
  *
@@ -52,7 +54,18 @@ public interface Join<Z, X> extends From<Z, X> {
     @Nonnull
     Join<Z, X> on(@Nonnull BooleanExpression... restrictions);
 
-    /** 
+    /**
+     * Modify the join to restrict the result according to the
+     * specified ON condition and return the join object.
+     * Replaces the previous ON condition, if any.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified join object
+     * @since 4.0
+     */
+    @Nonnull
+    Join<Z, X> on(@Nonnull List<? extends Expression<Boolean>> restrictions);
+
+    /**
      * Return the predicate that corresponds to the ON 
      * restriction(s) on the join, or null if no ON condition 
      * has been specified.
@@ -92,6 +105,7 @@ public interface Join<Z, X> extends From<Z, X> {
      * @return this join downcast to the given type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends X> Join<Z, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/ListJoin.java
+++ b/api/src/main/java/jakarta/persistence/criteria/ListJoin.java
@@ -42,6 +42,7 @@ public interface ListJoin<Z, E>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     ListJoin<Z, E> on(@Nonnull Expression<Boolean> restriction);
 
@@ -53,14 +54,28 @@ public interface ListJoin<Z, E>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     ListJoin<Z, E> on(@Nonnull BooleanExpression... restrictions);
+
+    /**
+     * Modify the join to restrict the result according to the
+     * specified ON condition and return the join object.
+     * Replaces the previous ON condition, if any.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified join object
+     * @since 4.0
+     */
+    @Override
+    @Nonnull
+    ListJoin<Z, E> on(@Nonnull List<? extends Expression<Boolean>> restrictions);
 
     /**
      * Return the metamodel representation for the list attribute.
      * @return metamodel type representing the {@code List} that is
      *         the target of the join
      */
+    @Override
     @Nonnull
     ListAttribute<? super Z, E> getModel();
 
@@ -83,6 +98,7 @@ public interface ListJoin<Z, E>
      * @return this join downcast to the given element type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends E> ListJoin<Z, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/MapJoin.java
+++ b/api/src/main/java/jakarta/persistence/criteria/MapJoin.java
@@ -17,6 +17,8 @@
 package jakarta.persistence.criteria;
 
 import jakarta.annotation.Nonnull;
+
+import java.util.List;
 import java.util.Map;
 import jakarta.persistence.metamodel.MapAttribute;
 
@@ -42,6 +44,7 @@ public interface MapJoin<Z, K, V>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     MapJoin<Z, K, V> on(@Nonnull Expression<Boolean> restriction);
 
@@ -53,14 +56,28 @@ public interface MapJoin<Z, K, V>
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     MapJoin<Z, K, V> on(@Nonnull BooleanExpression... restrictions);
+
+    /**
+     * Modify the join to restrict the result according to the
+     * specified ON condition and return the join object.
+     * Replaces the previous ON condition, if any.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified join object
+     * @since 4.0
+     */
+    @Override
+    @Nonnull
+    MapJoin<Z, K, V> on(@Nonnull List<? extends Expression<Boolean>> restrictions);
 
     /**
      * Return the metamodel representation for the map attribute.
      * @return metamodel type representing the {@code Map} that is
      *         the target of the join
      */
+    @Override
     @Nonnull
     MapAttribute<? super Z, K, V> getModel();
     
@@ -93,6 +110,7 @@ public interface MapJoin<Z, K, V>
      * @return this join downcast to the given value type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends V> MapJoin<Z, K, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/PluralJoin.java
+++ b/api/src/main/java/jakarta/persistence/criteria/PluralJoin.java
@@ -38,6 +38,7 @@ public interface PluralJoin<Z, C, E> extends Join<Z, E> {
      * @return metamodel collection-valued attribute corresponding
      *         to the target of the join
      */
+    @Override
     @Nonnull
     PluralAttribute<? super Z, C, E> getModel();
 
@@ -48,6 +49,7 @@ public interface PluralJoin<Z, C, E> extends Join<Z, E> {
      * @return this plural join downcast to the given element type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends E> PluralJoin<Z, ?, T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/Root.java
+++ b/api/src/main/java/jakarta/persistence/criteria/Root.java
@@ -33,6 +33,7 @@ public interface Root<X> extends From<X, X> {
      * Return the metamodel entity corresponding to the root.
      * @return metamodel entity corresponding to the root
      */
+    @Override
     @Nonnull
     EntityType<X> getModel();
 
@@ -43,6 +44,7 @@ public interface Root<X> extends From<X, X> {
      * @return this root downcast to the given type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends X> Root<T> treat(@Nonnull Class<T> type);
 }

--- a/api/src/main/java/jakarta/persistence/criteria/SetJoin.java
+++ b/api/src/main/java/jakarta/persistence/criteria/SetJoin.java
@@ -17,6 +17,8 @@
 package jakarta.persistence.criteria;
 
 import jakarta.annotation.Nonnull;
+
+import java.util.List;
 import java.util.Set;
 import jakarta.persistence.metamodel.SetAttribute;
 
@@ -40,6 +42,7 @@ public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     SetJoin<Z, E> on(@Nonnull Expression<Boolean> restriction);
 
@@ -51,14 +54,28 @@ public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
      * @return the modified join object
      * @since 2.1
      */
+    @Override
     @Nonnull
     SetJoin<Z, E> on(@Nonnull BooleanExpression... restrictions);
+
+    /**
+     * Modify the join to restrict the result according to the
+     * specified ON condition and return the join object.
+     * Replaces the previous ON condition, if any.
+     * @param restrictions  zero or more restriction predicates
+     * @return the modified join object
+     * @since 4.0
+     */
+    @Override
+    @Nonnull
+    SetJoin<Z, E> on(@Nonnull List<? extends Expression<Boolean>> restrictions);
 
     /**
      * Return the metamodel representation for the set attribute.
      * @return metamodel type representing the {@code Set} that is
      *         the target of the join
      */
+    @Override
     @Nonnull
     SetAttribute<? super Z, E> getModel();
 
@@ -69,6 +86,7 @@ public interface SetJoin<Z, E> extends PluralJoin<Z, Set<E>, E> {
      * @return this join downcast to the given element type
      * @since 4.0
      */
+    @Override
     @Nonnull
     <T extends E> SetJoin<Z, T> treat(@Nonnull Class<T> type);
 }


### PR DESCRIPTION
for consistency with what we already did to CriteriaQuery in 3.2

cc @beikov

(also add some missing `@Override` annotations)