### PR TITLE
Address issues in validation-related TCK tests

### DIFF
--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/validation/PersistenceTckValidatorFactory.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/validation/PersistenceTckValidatorFactory.java
@@ -34,6 +34,7 @@ import org.opentest4j.AssertionFailedError;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class PersistenceTckValidatorFactory implements ValidatorFactory, Validator, ValidatorContext {
@@ -141,13 +142,16 @@ public class PersistenceTckValidatorFactory implements ValidatorFactory, Validat
         return this;
     }
 
-    public void assertValidCallsContain(ValidCallArgument... validCallArgument) {
+    public void assertValidCallsContainOnly(ValidCallArgument... validCallArgument) {
         for (ValidCallArgument validCallArg : validCallArgument) {
             if (!validCallArguments.remove(validCallArg)) {
                 throw new AssertionFailedError("Invalid call argument: " + validCallArg);
             }
         }
-        validCallArguments.clear();
+
+        if (!validCallArguments.isEmpty()) {
+            throw new AssertionFailedError("There are unexpected validation calls: " + validCallArguments);
+        }
     }
 
     public void assertNoValidationCalls() {
@@ -155,6 +159,18 @@ public class PersistenceTckValidatorFactory implements ValidatorFactory, Validat
     }
 
     public record ValidCallArgument(Object entity, Class<?>[] groups) {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof ValidCallArgument that
+                    && Objects.equals(entity, that.entity)
+                    && Arrays.equals(groups, that.groups);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(entity, Arrays.hashCode(groups));
+        }
+
         @Override
         public String toString() {
             return "ValidCallArgument{" +

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
@@ -81,7 +81,7 @@ public class Client1 extends PMClientBase {
             emf.runInTransaction(em -> {
                 em.persist(entity);
             });
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -97,14 +97,14 @@ public class Client1 extends PMClientBase {
                 em.persist(entity);
             });
             // on insert:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
 
             emf.runInTransaction(em -> {
                 Order1 forUpdate = em.find(Order1.class, entity.getId());
                 forUpdate.setTotal(forUpdate.getTotal() + 100);
             });
             // on update:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -120,7 +120,7 @@ public class Client1 extends PMClientBase {
                 entityAgent.insert(entity);
             });
             // on insert:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -136,7 +136,7 @@ public class Client1 extends PMClientBase {
                 entityAgent.upsert(entity);
             });
             // on upsert:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -152,7 +152,7 @@ public class Client1 extends PMClientBase {
                 entityAgent.insert(entity);
             });
             // on insert:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
 
             emf.runInTransaction(EntityAgent.class, entityAgent -> {
                 Order1 forUpdate = entityAgent.get(Order1.class, entity.getId());
@@ -160,7 +160,7 @@ public class Client1 extends PMClientBase {
                 entityAgent.update(forUpdate);
             });
             // on update:
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
@@ -189,26 +189,27 @@ public class Client2 extends PMClientBase {
             emf.runInTransaction(em -> {
                 em.persist(entity);
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PrePersistGroup.class));
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreInsertGroup.class, PreInsertOtherGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PrePersistGroup.class),
+                    PersistenceTckValidatorFactory.validCall(entity, PreInsertGroup.class, PreInsertOtherGroup.class));
+
             Order2 detached = emf.callInTransaction(em -> {
                 Order2 order2 = em.find(Order2.class, entity.getId());
                 order2.setTotal(order2.getTotal() + 100);
                 return order2;
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
             emf.runInTransaction(em -> {
-                em.merge(detached);
-                detached.setTotal(detached.getTotal() + 100);
+                Order2 merged = em.merge(detached);
+                merged.setTotal(detached.getTotal() + 100);
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreMergeGroup.class));
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreMergeGroup.class),
+                    PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
 
             emf.runInTransaction(em -> {
                 em.remove(em.getReference(Order2.class, entity.getId()));
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreRemoveGroup.class));
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreDeleteGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreRemoveGroup.class),
+                    PersistenceTckValidatorFactory.validCall(entity, PreDeleteGroup.class));
         }
     }
 
@@ -230,25 +231,25 @@ public class Client2 extends PMClientBase {
             emf.runInTransaction(EntityAgent.class, entityAgent -> {
                 entityAgent.insert(entity);
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreInsertGroup.class, PreInsertOtherGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreInsertGroup.class, PreInsertOtherGroup.class));
 
             emf.runInTransaction(EntityAgent.class, entityAgent -> {
                 entity.setTotal(entity.getTotal() + 100);
                 entityAgent.upsert(entity);
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreUpsertGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreUpsertGroup.class));
 
             emf.runInTransaction(EntityAgent.class, entityAgent -> {
                 Order2 forUpdate = entityAgent.get(Order2.class, entity.getId());
                 forUpdate.setTotal(forUpdate.getTotal() + 100);
                 entityAgent.update(forUpdate);
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreUpdateGroup.class));
 
             emf.runInTransaction(EntityAgent.class, entityAgent -> {
                 entityAgent.delete(entityAgent.get(Order2.class, entity.getId()));
             });
-            validatorFactory.assertValidCallsContain(PersistenceTckValidatorFactory.validCall(entity, PreDeleteGroup.class));
+            validatorFactory.assertValidCallsContainOnly(PersistenceTckValidatorFactory.validCall(entity, PreDeleteGroup.class));
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
@@ -83,7 +83,7 @@ public class Client3 extends PMClientBase {
             emf.runInTransaction(em -> {
                 em.persist(entity);
             });
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -112,7 +112,7 @@ public class Client3 extends PMClientBase {
             emf.runInTransaction(em -> {
                 em.persist(entity);
             });
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -160,7 +160,7 @@ public class Client3 extends PMClientBase {
             emf.runInTransaction(EntityAgent.class, em -> {
                 em.insert(entity);
             });
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 
@@ -189,7 +189,7 @@ public class Client3 extends PMClientBase {
             emf.runInTransaction(EntityAgent.class,em -> {
                 em.insert(entity);
             });
-            validatorFactory.assertValidCallsContain(validCall(entity, Default.class));
+            validatorFactory.assertValidCallsContainOnly(validCall(entity, Default.class));
         }
     }
 


### PR DESCRIPTION
Record-based equals wasn't correctly comparing the arrays, and in the merge-update case, the detached entity was modified rather than the merged one.

With these adjustments, the tests work fine and pass.