### PR TITLE
clarify/tighten expectations around AttributeNode removal/addition

### DIFF
--- a/api/src/main/java/jakarta/persistence/Graph.java
+++ b/api/src/main/java/jakarta/persistence/Graph.java
@@ -94,9 +94,7 @@ public interface Graph<T> {
      *
      * <p>Added nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#EAGER},
-     * except when the effect of this call is simply to cancel the
-     * effect of a prior {@linkplain #removeAttributeNode removal}.
+     * {@link AttributeNode} with option {@link FetchType#EAGER}.
      *
      * @param attribute  attribute
      * @param <Y> the type of the attribute
@@ -290,9 +288,9 @@ public interface Graph<T> {
     void addAttributeNodes(@Nonnull Attribute<? super T, ?>... attribute);
 
     /**
-     * Add a node to the graph that corresponds to a managed type.
-     * This allows for construction of multi-node entity graphs
-     * that include related managed types.
+     * Add a node to the graph representing a managed type. This
+     * allows for construction of multi-node entity graphs that
+     * include related managed types.
      *
      * @param attribute the attribute
      * @param <X> the managed type of the attribute
@@ -306,11 +304,11 @@ public interface Graph<T> {
     <X> Subgraph<X> addSubgraph(@Nonnull Attribute<? super T, X> attribute);
 
     /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance. This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity
-     * graph. Subclass subgraphs will automatically include the
-     * specified attributes of superclass subgraphs.
+     * Add a node to the graph representing a managed type with
+     * inheritance. This allows for multiple subclass subgraphs
+     * to be defined for this node of the entity graph. Subclass
+     * subgraphs automatically include the specified attributes
+     * of superclass subgraphs.
      *
      * @param attribute the attribute
      * @param type an entity subclass of the attribute type
@@ -328,9 +326,9 @@ public interface Graph<T> {
                                        @Nonnull Class<Y> type);
 
     /**
-     * Add a node to the graph that corresponds to a managed type.
-     * This allows for construction of multi-node entity graphs
-     * that include related managed types.
+     * Add a node to the graph representing a managed type. This
+     * allows for construction of multi-node entity graphs that
+     * include related managed types.
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -352,11 +350,11 @@ public interface Graph<T> {
     <X> Subgraph<X> addSubgraph(@Nonnull String attributeName);
 
     /**
-     * Add a node to the graph that corresponds to a managed
-     * type with inheritance. This allows for multiple subclass
-     * subgraphs to be defined for this node of the entity
-     * graph. Subclass subgraphs will automatically include the
-     * specified attributes of superclass subgraphs
+     * Add a node to the graph representing a managed type with
+     * inheritance. This allows for multiple subclass subgraphs
+     * to be defined for this node of the entity graph. Subclass
+     * subgraphs automatically include the specified attributes
+     * of superclass subgraphs.
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -380,7 +378,7 @@ public interface Graph<T> {
                                 @Nonnull Class<X> type);
 
     /**
-     * Add a node to the graph that corresponds to a collection element
+     * Add a node to the graph representing a collection element
      * that is a managed type. This allows for construction of
      * multi-node entity graphs that include related managed types.
      *
@@ -398,7 +396,7 @@ public interface Graph<T> {
     <E> Subgraph<E> addElementSubgraph(@Nonnull PluralAttribute<? super T, ?, E> attribute);
 
     /**
-     * Add a node to the graph that corresponds to a collection element
+     * Add a node to the graph representing a collection element
      * that is a managed type. This allows for construction of
      * multi-node entity graphs that include related managed types.
      *
@@ -418,7 +416,7 @@ public interface Graph<T> {
                                               @Nonnull Class<E> type);
 
     /**
-     * Add a node to the graph that corresponds to a collection element
+     * Add a node to the graph representing a collection element
      * that is a managed type. This allows for construction of
      * multi-node entity graphs that include related managed types.
      *
@@ -442,7 +440,7 @@ public interface Graph<T> {
     <X> Subgraph<X> addElementSubgraph(@Nonnull String attributeName);
 
     /**
-     * Add a node to the graph that corresponds to a collection element
+     * Add a node to the graph that representing a collection element
      * that is a managed type. This allows for construction of
      * multi-node entity graphs that include related managed types.
      *
@@ -468,9 +466,9 @@ public interface Graph<T> {
                                        @Nonnull Class<X> type);
 
     /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multi-node entity graphs that include related managed types.
+     * Add a node to the graph representing a map key that is a
+     * managed type. This allows for construction of multi-node
+     * entity graphs that include related managed types.
      *
      * @param attribute the attribute
      * @param <K> the managed type of the map key
@@ -484,11 +482,11 @@ public interface Graph<T> {
     <K> Subgraph<K> addMapKeySubgraph(@Nonnull MapAttribute<? super T, K, ?> attribute);
 
     /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types. Subclass subgraphs will automatically include
-     * the specified attributes of superclass subgraphs
+     * Add a node to the graph representing a map key that is a
+     * managed type with inheritance. This allows for construction
+     * of multi-node entity graphs that include related managed
+     * types. Subclass subgraphs automatically include the
+     * specified attributes of superclass subgraphs.
      *
      * @param attribute the attribute
      * @param type an entity subclass of the map key type
@@ -504,9 +502,9 @@ public interface Graph<T> {
                                              @Nonnull Class<K> type);
 
     /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type. This allows for construction of
-     * multi-node entity graphs that include related managed types.
+     * Add a node to the graph representing a map key that is a
+     * managed type. This allows for construction of multi-node
+     * entity graphs that include related managed types.
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -528,11 +526,11 @@ public interface Graph<T> {
     <X> Subgraph<X> addKeySubgraph(@Nonnull String attributeName);
 
     /**
-     * Add a node to the graph that corresponds to a map key
-     * that is a managed type with inheritance. This allows for
-     * construction of multi-node entity graphs that include related
-     * managed types. Subclass subgraphs will include the specified
-     * attributes of superclass subgraphs
+     * Add a node to the graph representing a map key that is a
+     * managed type with inheritance. This allows for construction
+     * of multi-node entity graphs that include related managed types.
+     * Subclass subgraphs will include the specified attributes of
+     * superclass subgraphs
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -556,10 +554,13 @@ public interface Graph<T> {
                                    @Nonnull Class<X> type);
 
     /**
-     * Return the attribute nodes corresponding to the attributes of
-     * this managed type that are included in the graph. The
-     * {@linkplain AttributeNode#getOptions options} of the returned
-     * nodes may be used to distinguish added nodes from removed nodes.
+     * Return the attribute nodes representing the persistent
+     * attributes of this managed type that were explicitly
+     * {@linkplain #addAttributeNode included in (added to)} or
+     * {@linkplain #removeAttributeNode excluded from (removed from)}
+     * the graph. The {@linkplain AttributeNode#getOptions options}
+     * of the returned nodes may be used to distinguish added nodes
+     * from removed nodes.
      * <ul>
      * <li>Added nodes are represented by instances of
      *     {@link AttributeNode} with option {@link FetchType#EAGER}.

--- a/api/src/main/java/jakarta/persistence/Graph.java
+++ b/api/src/main/java/jakarta/persistence/Graph.java
@@ -61,13 +61,13 @@ public interface Graph<T> {
 
     /**
      * Get an existing attribute node for the attribute with the given
-     * name, or add a new attribute node if there is no existing node.
+     * name, or add a new attribute node if there is no existing node,
+     * cancelling the effect of any prior
+     * {@linkplain #removeAttributeNode removal}.
      *
      * <p>Added nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#EAGER},
-     * except when the effect of this call is simply to cancel the
-     * effect of a prior {@linkplain #removeAttributeNode removal}.
+     * {@link AttributeNode} with option {@link FetchType#EAGER}.
      *
      * @param attributeName the name of an attribute of the managed type
      * @param <Y> the type of the attribute
@@ -89,7 +89,8 @@ public interface Graph<T> {
 
     /**
      * Get an existing attribute node for the given attribute, or add
-     * a new attribute node if there is no existing node.
+     * a new attribute node if there is no existing node, cancelling
+     * the effect of any prior {@linkplain #removeAttributeNode removal}.
      *
      * <p>Added nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
@@ -178,19 +179,16 @@ public interface Graph<T> {
     <Y> AttributeNode<Y> getAttributeNode(@Nonnull Attribute<? super T, Y> attribute);
 
     /**
-     * Remove an attribute node from the entity graph.
+     * Remove an attribute node from the entity graph, cancelling the
+     * effect of any prior {@linkplain #addAttributeNode addition}.
      * When this graph is interpreted as a load graph, this operation
      * suppresses inclusion of an attribute mapped for eager fetching.
      * The effect of this call may be overridden by subsequent
      * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
-     * If there is no existing node for the given attribute name, this
-     * operation has no effect.
      *
      * <p>Removed nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#LAZY}, except
-     * when the effect of this call is simply to cancel the effect of a
-     * prior {@linkplain #addAttributeNode addition}.
+     * {@link AttributeNode} with option {@link FetchType#LAZY}.
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -207,19 +205,22 @@ public interface Graph<T> {
     void removeAttributeNode(@Nonnull String attributeName);
 
     /**
-     * Remove an attribute node from the entity graph.
+     * Remove an attribute node from the entity graph, cancelling the
+     * effect of any prior {@linkplain #addAttributeNode addition}.
      * When this graph is interpreted as a load graph, this operation
      * suppresses inclusion of an attribute mapped for eager fetching.
      * The effect of this call may be overridden by subsequent
      * invocations of {@link #addAttributeNode} or {@link #addSubgraph}.
-     * If there is no existing node for the given attribute, this
-     * operation has no effect.
      *
      * <p>Removed nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#LAZY}, except
-     * when the effect of this call is simply to cancel the effect of a
-     * prior {@linkplain #addAttributeNode addition}.
+     * {@link AttributeNode} with option {@link FetchType#LAZY}.
+     *
+     * @apiNote This operation does not literally remove a node from
+     * the entity graph object; instead, it suppresses the inclusion
+     * of an edge in the logical graph of fetched associations that
+     * is inferred from this entity graph when it is interpreted as
+     * a load graph or fetch graph in the context of mapping metadata.
      *
      * @param attribute  attribute
      *
@@ -228,7 +229,8 @@ public interface Graph<T> {
     void removeAttributeNode(@Nonnull Attribute<? super T, ?> attribute);
 
     /**
-     * Remove all attribute nodes of the given attribute type.
+     * Remove all attribute nodes of the given attribute type, cancelling
+     * the effect of any prior {@linkplain #addAttributeNode additions}.
      * When this graph is interpreted as a load graph, this operation
      * suppresses inclusion of attributes mapped for eager fetching.
      * The effect of this call may be overridden by subsequent
@@ -236,9 +238,7 @@ public interface Graph<T> {
      *
      * <p>Removed nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#LAZY}, except
-     * when the effect of this call is simply to cancel the effect of a
-     * prior {@linkplain #addAttributeNode addition}.
+     * {@link AttributeNode} with option {@link FetchType#LAZY}.
      *
      * @param nodeType the type of attribute to remove
      *
@@ -247,16 +247,16 @@ public interface Graph<T> {
     void removeAttributeNodes(@Nonnull Attribute.PersistentAttributeType nodeType);
 
     /**
-     * Add one or more attribute nodes to the entity graph.
+     * Add one or more attribute nodes to the entity graph,
+     * cancelling the effect of any prior
+     * {@linkplain #removeAttributeNode removals}.
      * If there is already an existing node for one of the given
-     * attribute names, that particular argument is ignored and
-     * has no effect.
+     * attribute names, and it is not marked for removal, that
+     * particular argument is ignored and has no effect.
      *
      * <p>Added nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#EAGER},
-     * except when the effect of this call is simply to cancel the
-     * effect of a prior {@linkplain #removeAttributeNode removal}.
+     * {@link AttributeNode} with option {@link FetchType#EAGER}.
      *
      * @param attributeName the name of an attribute of the managed
      *                      type
@@ -272,16 +272,16 @@ public interface Graph<T> {
     void addAttributeNodes(@Nonnull String... attributeName);
 
     /**
-     * Add one or more attribute nodes to the entity graph.
+     * Add one or more attribute nodes to the entity graph,
+     * cancelling the effect of any prior
+     * {@linkplain #removeAttributeNode removals}.
      * If there is already an existing node for one of the given
-     * attributes, that particular argument is ignored and has no
-     * effect.
+     * attributes, and it is not marked for removal, that particular
+     * argument is ignored and has no effect.
      *
      * <p>Added nodes are reflected in the list of
      * {@linkplain #getAttributeNodes child nodes} as instances of
-     * {@link AttributeNode} with option {@link FetchType#EAGER},
-     * except when the effect of this call is simply to cancel the
-     * effect of a prior {@linkplain #removeAttributeNode removal}.
+     * {@link AttributeNode} with option {@link FetchType#EAGER}.
      *
      * @param attribute  attribute
      * @throws IllegalStateException if this EntityGraph has been


### PR DESCRIPTION
When I sat down to actually implement this and pass the TCK, I realized that the current language here wasn't really quite right in light of the subtle but important semantic differences between "load" and "fetch" graphs, and given that we don't know what sort of graph were are constructing when we are constructing it (a really crazy aspect of the design of JPA 2.1 is that there are two kinds of graphs with quite different semantics, but the graph itself doesn't know what kind of graph it is).