### PR TITLE
add TCK tests for @Fetch with no named graph

### DIFF
--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
+import static jakarta.persistence.Persistence.getPersistenceUtil;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,7 +79,7 @@ public class Client extends PMClientBase {
         lazyGraph.addAttributeNode("publisher").addOption(FetchType.LAZY);
 
         FetchOptionBook lazyBook = getEntityManager().find(lazyGraph, 1);
-        assertFalse(Persistence.getPersistenceUtil().isLoaded(lazyBook, "publisher"));
+        assertFalse(getPersistenceUtil().isLoaded(lazyBook, "publisher"));
 
         getEntityManager().clear();
 
@@ -86,8 +87,34 @@ public class Client extends PMClientBase {
         eagerGraph.addAttributeNode("publisher").addOption(FetchType.EAGER);
 
         FetchOptionBook eagerBook = getEntityManager().find(eagerGraph, 1);
-        assertTrue(Persistence.getPersistenceUtil().isLoaded(eagerBook, "publisher"));
-        assertTrue(Persistence.getPersistenceUtil().isLoaded(eagerBook.getPublisher()));
+        assertTrue(getPersistenceUtil().isLoaded(eagerBook, "publisher"));
+        assertTrue(getPersistenceUtil().isLoaded(eagerBook.getPublisher()));
+    }
+
+    /**
+     * Tests Jakarta Persistence 4.0 fetch options declared directly on a
+     * mapped attribute. The test verifies an unqualified {@code @Fetch}
+     * annotation applies to a plain find operation without an entity graph.
+     */
+    @Test
+    public void fetchAnnotationWithoutGraphTest() {
+        FetchOptionBook book = getEntityManager().find(FetchOptionBook.class, 1);
+
+        assertTrue(getPersistenceUtil().isLoaded(book, "defaultFetchPublisher"));
+        assertTrue(getPersistenceUtil().isLoaded(book.getDefaultFetchPublisher()));
+    }
+
+    /**
+     * Tests Jakarta Persistence 4.0 fetch options declared directly on a
+     * mapped attribute. The test verifies an unqualified {@code @Fetch}
+     * annotation overrides the mapping fetch type when no entity graph is used.
+     */
+    @Test
+    public void fetchAnnotationLazyWithoutGraphTest() {
+        FetchOptionBook book = getEntityManager().find(FetchOptionBook.class, 1);
+
+        assertFalse(getPersistenceUtil().isLoaded(book, "lazyFetchPublisher")
+                && getPersistenceUtil().isLoaded(book.getLazyFetchPublisher()));
     }
 
     /**
@@ -152,16 +179,21 @@ public class Client extends PMClientBase {
                 getEntityManager().createEntityGraph(FetchOptionBook.class);
         graph.removeAttributeNode("publisher");
         FetchOptionBook book = getEntityManager().find(graph, 1);
-        assertFalse(Persistence.getPersistenceUtil().isLoaded(book, "publisher")
-                && Persistence.getPersistenceUtil().isLoaded(book.getPublisher()));
+        assertFalse(getPersistenceUtil().isLoaded(book, "publisher")
+                && getPersistenceUtil().isLoaded(book.getPublisher()));
     }
 
     private void createTestData() {
         EntityTransaction transaction = getEntityTransaction();
         transaction.begin();
         FetchOptionPublisher publisher = new FetchOptionPublisher(1, "Publisher");
+        FetchOptionPublisher defaultFetchPublisher = new FetchOptionPublisher(2, "Default Fetch Publisher");
+        FetchOptionPublisher lazyFetchPublisher = new FetchOptionPublisher(3, "Lazy Fetch Publisher");
         getEntityManager().persist(publisher);
-        getEntityManager().persist(new FetchOptionBook(1, "Alpha", publisher));
+        getEntityManager().persist(defaultFetchPublisher);
+        getEntityManager().persist(lazyFetchPublisher);
+        getEntityManager().persist(new FetchOptionBook(1, "Alpha", publisher,
+                defaultFetchPublisher, lazyFetchPublisher));
         transaction.commit();
         getEntityManager().clear();
     }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/FetchOptionBook.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/FetchOptionBook.java
@@ -17,6 +17,7 @@
 package ee.jakarta.tck.persistence.jpa40.fetchoption;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.Fetch;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
@@ -33,6 +34,14 @@ public class FetchOptionBook {
     @ManyToOne(fetch = FetchType.EAGER)
     private FetchOptionPublisher publisher;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Fetch
+    private FetchOptionPublisher defaultFetchPublisher;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @Fetch(type = FetchType.LAZY)
+    private FetchOptionPublisher lazyFetchPublisher;
+
     public FetchOptionBook() {
     }
 
@@ -42,7 +51,24 @@ public class FetchOptionBook {
         this.publisher = publisher;
     }
 
+    public FetchOptionBook(Integer id, String title, FetchOptionPublisher publisher,
+            FetchOptionPublisher defaultFetchPublisher, FetchOptionPublisher lazyFetchPublisher) {
+        this.id = id;
+        this.title = title;
+        this.publisher = publisher;
+        this.defaultFetchPublisher = defaultFetchPublisher;
+        this.lazyFetchPublisher = lazyFetchPublisher;
+    }
+
     public FetchOptionPublisher getPublisher() {
         return publisher;
+    }
+
+    public FetchOptionPublisher getDefaultFetchPublisher() {
+        return defaultFetchPublisher;
+    }
+
+    public FetchOptionPublisher getLazyFetchPublisher() {
+        return lazyFetchPublisher;
     }
 }


### PR DESCRIPTION
We were missing a test for standalone `@Fetch`.