### PR TITLE
Remove build throttling from snapshots publishing

### DIFF
--- a/ci/snapshot-publish/Jenkinsfile
+++ b/ci/snapshot-publish/Jenkinsfile
@@ -20,11 +20,6 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 pipeline {
 	agent none
 	options {
-		// Wait for 1h before publishing snapshots, in case there's more commits.
-		quietPeriod 3600
-		// In any case, never publish snapshots more than once per hour.
-		rateLimitBuilds(throttle: [count: 1, durationName: 'hour', userBoost: true])
-
 		buildDiscarder(logRotator(numToKeepStr: '3', artifactNumToKeepStr: '3'))
 		disableConcurrentBuilds(abortPrevious: false)
 	}


### PR DESCRIPTION
To simplify the work on TCK and adding more tests. With snapshots published after the merge, we would be able to run the tests without waiting for 1h and no need to rebuild locally