### PR TITLE
clarify that a bytecode processor is permitted to take care of unfinaling fields, classes, methods

### DIFF
--- a/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
+++ b/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
@@ -20,14 +20,32 @@ import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 
 import java.security.ProtectionDomain;
+import java.util.Map;
 
 /**
- * A persistence provider supplies an instance of this 
- * interface to the {@link PersistenceUnitInfo#addTransformer}
- * method. The supplied transformer instance will get 
- * called to transform entity class files when they are 
- * loaded or redefined. The transformation occurs before  
- * the class is defined by the JVM.
+ * Performs standard and provider-specific enhancement of managed
+ * classes. An instance of {@link ClassTransformer} is encouraged
+ * to:
+ * <ul>
+ * <li>add a {@code protected} constructor with no parameters that
+ *     initializes every field to its standard default value to
+ *     each entity class that lacks a constructor with no parameters,
+ * <li>remove {@code final} modifiers from entity classes, fields,
+ *     and methods, and
+ * <li>perform additional provider-specific enhancements as necessary
+ *     to support lazy loading, proxying, and so on.
+ * </ul>
+ * <p>
+ * A {@link ClassTransformer} is specific to a persistence provider,
+ * and a class transformed by a given provider might not be usable
+ * with a different provider.
+ * <p>
+ * A persistence provider supplies an instance of this interface to
+ * the {@link PersistenceUnitInfo#addTransformer} method, and returns
+ * an instance from {@link PersistenceProvider#getClassTransformer}.
+ * The supplied transformer instance is called to transform entity
+ * class files when they are loaded or redefined. The transformation
+ * occurs before the class is defined by the Java Virtual Machine.
  *
  * @apiNote This is an SPI interface forming part of the Jakarta EE
  * container / persistence provider contract. It is not intended for

--- a/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
+++ b/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * <ul>
  * <li>to each entity class that lacks a constructor with no parameters,
  *     add a {@code protected} constructor with no parameters that
- *     initializes every field to its standard default value 
+ *     initializes every field to its standard default value,
  * <li>remove {@code final} modifiers from entity classes, fields,
  *     and methods, and
  * <li>perform additional provider-specific enhancements as necessary

--- a/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
+++ b/api/src/main/java/jakarta/persistence/spi/ClassTransformer.java
@@ -27,9 +27,9 @@ import java.util.Map;
  * classes. An instance of {@link ClassTransformer} is encouraged
  * to:
  * <ul>
- * <li>add a {@code protected} constructor with no parameters that
- *     initializes every field to its standard default value to
- *     each entity class that lacks a constructor with no parameters,
+ * <li>to each entity class that lacks a constructor with no parameters,
+ *     add a {@code protected} constructor with no parameters that
+ *     initializes every field to its standard default value 
  * <li>remove {@code final} modifiers from entity classes, fields,
  *     and methods, and
  * <li>perform additional provider-specific enhancements as necessary
@@ -41,7 +41,7 @@ import java.util.Map;
  * with a different provider.
  * <p>
  * A persistence provider supplies an instance of this interface to
- * the {@link PersistenceUnitInfo#addTransformer} method, and returns
+ * the {@link PersistenceUnitInfo#addTransformer} method and returns
  * an instance from {@link PersistenceProvider#getClassTransformer}.
  * The supplied transformer instance is called to transform entity
  * class files when they are loaded or redefined. The transformation

--- a/spec/src/main/asciidoc/ch02-entities.adoc
+++ b/spec/src/main/asciidoc/ch02-entities.adoc
@@ -39,6 +39,8 @@ declared as an `entity` in its XML descriptor.
 
 - The entity class must be non-`final`. Every method and persistent
   instance variable of the entity class must also be non-`final`.
+  This requirement might be satisfied via source or bytecode processing
+  by the build process or runtime environment.
 
 An entity might be an abstract class, or it might be a concrete class.
 An entity may extend a non-entity class, or it may extend another entity

--- a/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
+++ b/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
@@ -597,10 +597,30 @@ include::../../../../api/src/main/java/jakarta/persistence/ValidationMode.java[l
 
 ==== jakarta.persistence.spi.ClassTransformer Interface
 
-The `ClassTransformer` interface found in <<_classtransformer_>> may be
+The `ClassTransformer` interface found in <<_classtransformer_>> performs
+standard and provider-specific enhancement of managed classes. It may be
 implemented by a persistence provider to transform entities and managed
 classes at class load time or at class redefinition time. A persistence
 provider is not required to implement this interface.
+
+An instance of `ClassTransformer` is encouraged to:
+
+* add a `protected` constructor with no parameters initializes every field
+  to its standard default value to each entity class that lacks a constructor
+  with no parameters,
+* remove `final` modifiers from entity classes, fields, and methods, and
+* perform additional provider-specific enhancements as necessary to support
+  lazy loading, proxying, and so on.
+
+A `ClassTransformer` is specific to a persistence provider, and a class
+transformed by a given provider might not be usable with a different provider.
+
+A persistence provider supplies an instance of this interface to the
+`PersistenceUnitInfo.addTransformer` method, and returns an instance from
+`PersistenceProvider.getClassTransformer`. The supplied transformer instance
+is called to transform entity class files when they are loaded or redefined.
+The transformation occurs before the class is defined by the Java Virtual
+Machine.
 
 === jakarta.persistence.Persistence Class [[a13443]]
 

--- a/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
+++ b/spec/src/main/asciidoc/ch09-container-provider-contracts.adoc
@@ -605,9 +605,9 @@ provider is not required to implement this interface.
 
 An instance of `ClassTransformer` is encouraged to:
 
-* add a `protected` constructor with no parameters initializes every field
-  to its standard default value to each entity class that lacks a constructor
-  with no parameters,
+* to each entity class that lacks a constructor with no parameters,
+  add a `protected` constructor with no parameters that initializes
+  every field to its standard default value,
 * remove `final` modifiers from entity classes, fields, and methods, and
 * perform additional provider-specific enhancements as necessary to support
   lazy loading, proxying, and so on.
@@ -616,7 +616,7 @@ A `ClassTransformer` is specific to a persistence provider, and a class
 transformed by a given provider might not be usable with a different provider.
 
 A persistence provider supplies an instance of this interface to the
-`PersistenceUnitInfo.addTransformer` method, and returns an instance from
+`PersistenceUnitInfo.addTransformer` method and returns an instance from
 `PersistenceProvider.getClassTransformer`. The supplied transformer instance
 is called to transform entity class files when they are loaded or redefined.
 The transformation occurs before the class is defined by the Java Virtual


### PR DESCRIPTION
Let's say explicitly that a `ClassTransformer` is permitted to be the thing responsible for satisfying restrictions on entity classes.

Note that it was never _not_ allowed to do these things.