### PR TITLE
Make sure stored procedures are initialized in the tests that try to use them

### DIFF
--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -22,6 +22,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.System.Logger;
 import java.lang.reflect.InvocationTargetException;
@@ -40,7 +41,9 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
@@ -72,6 +75,8 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceException;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract public class PMClientBase implements UseEntityManager, UseEntityManagerFactory, java.io.Serializable {
 
@@ -1204,6 +1209,25 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
         try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
             return bufReader.lines().collect(Collectors.joining(System.lineSeparator()));
         }
+    }
+
+    protected Map<String, Object> storedProceduresExtraProperties() {
+        assertTrue(Objects.toString(myProps.get(JAKARTA_PERSISTENCE_JDBC_DRIVER), "").toLowerCase(Locale.ROOT).contains("postgresql"),
+                "This test only contains procedures for the PostgreSQL database. Running on other DBs may result in an unpredictable outcome.");
+        return Map.of(Persistence.SchemaManagementProperties.SCHEMAGEN_CREATE_SCRIPT_SOURCE,
+                new StringReader(
+                        "CREATE TABLE IF NOT EXISTS EMPLOYEE (HIREDATE date, ID integer not null, SALARY float4, FIRSTNAME varchar(255), LASTNAME varchar(255), primary key (ID)); \n"
+                                + "CREATE OR REPLACE PROCEDURE Integer_Proc(out pmax integer, out pmin integer, out pnull integer) LANGUAGE plpgsql AS $$ BEGIN SELECT MAX_VAL, MIN_VAL, NULL_VAL INTO pmax, pmin, pnull FROM Integer_Tab; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpOneFirstNameFromOut(out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=1; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpFirstNameFromOut(in IN_PARAM int, out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpLastNameFromInOut(inout INOUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT LASTNAME INTO INOUT_PARAM FROM EMPLOYEE WHERE ID=CAST(INOUT_PARAM AS int); END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpASCFromRS(out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME, HIREDATE, SALARY FROM EMPLOYEE ORDER BY ID ASC; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpFullByIdFromRS(in IN_PARAM int, out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME, HIREDATE, SALARY FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpIdFNameLNameFromRS(in IN_PARAM int, out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE GetEmpIdUsingHireDateFromOut(in IN_PARAM DATE, out OUT_PARAM int) LANGUAGE plpgsql AS $$ BEGIN SELECT ID INTO OUT_PARAM FROM EMPLOYEE WHERE HIREDATE=IN_PARAM; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE UpdateEmpSalaryColumn() LANGUAGE plpgsql AS $$ BEGIN UPDATE EMPLOYEE SET SALARY=0.00; END; $$ ;\n"
+                                + "CREATE OR REPLACE PROCEDURE DeleteAllEmp() LANGUAGE plpgsql AS $$ BEGIN DELETE FROM EMPLOYEE; END; $$ ;\n"
+                ));
     }
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
@@ -16,23 +16,18 @@
 
 package ee.jakarta.tck.persistence.core.StoredProcedureQuery;
 
-import java.io.StringReader;
 import java.lang.System.Logger;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 
-import jakarta.persistence.Persistence;
 import org.junit.jupiter.api.AfterEach;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.StoredProcedureQuery;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Client extends PMClientBase {
 
@@ -73,22 +68,7 @@ public class Client extends PMClientBase {
 
     @Override
     protected Map<String, Object> extraPersistenceUnitProperties() {
-        assertTrue(Objects.toString(myProps.get(JAKARTA_PERSISTENCE_JDBC_DRIVER), "").toLowerCase(Locale.ROOT).contains("postgresql"),
-                "This test only contains procedures for the PostgreSQL database. Running on other DBs may result in an unpredictable outcome.");
-        return Map.of(Persistence.SchemaManagementProperties.SCHEMAGEN_CREATE_SCRIPT_SOURCE,
-                new StringReader(
-                        "CREATE TABLE IF NOT EXISTS EMPLOYEE (HIREDATE date, ID integer not null, SALARY float4, FIRSTNAME varchar(255), LASTNAME varchar(255), primary key (ID)); \n"
-                                + "CREATE OR REPLACE PROCEDURE Integer_Proc(out pmax integer, out pmin integer, out pnull integer) LANGUAGE plpgsql AS $$ BEGIN SELECT MAX_VAL, MIN_VAL, NULL_VAL INTO pmax, pmin, pnull FROM Integer_Tab; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpOneFirstNameFromOut(out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=1; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpFirstNameFromOut(in IN_PARAM int, out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpLastNameFromInOut(inout INOUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT LASTNAME INTO INOUT_PARAM FROM EMPLOYEE WHERE ID=CAST(INOUT_PARAM AS int); END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpASCFromRS(out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME, HIREDATE, SALARY FROM EMPLOYEE ORDER BY ID ASC; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpFullByIdFromRS(in IN_PARAM int, out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME, HIREDATE, SALARY FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpIdFNameLNameFromRS(in IN_PARAM int, out ref refcursor) LANGUAGE plpgsql AS $$ BEGIN OPEN ref FOR SELECT ID, FIRSTNAME, LASTNAME FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE GetEmpIdUsingHireDateFromOut(in IN_PARAM DATE, out OUT_PARAM int) LANGUAGE plpgsql AS $$ BEGIN SELECT ID INTO OUT_PARAM FROM EMPLOYEE WHERE HIREDATE=IN_PARAM; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE UpdateEmpSalaryColumn() LANGUAGE plpgsql AS $$ BEGIN UPDATE EMPLOYEE SET SALARY=0.00; END; $$ ;\n"
-                                + "CREATE OR REPLACE PROCEDURE DeleteAllEmp() LANGUAGE plpgsql AS $$ BEGIN DELETE FROM EMPLOYEE; END; $$ ;\n"
-                ));
+        return storedProceduresExtraProperties();
     }
 
 	public List<List> getResultSetsFromStoredProcedure(StoredProcedureQuery spq) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
@@ -38,7 +38,6 @@ import jakarta.persistence.QueryFlushMode;
 import jakarta.persistence.StoredProcedureQuery;
 import jakarta.persistence.TemporalType;
 import jakarta.persistence.Timeout;
-import jakarta.persistence.TransactionRequiredException;
 import jakarta.persistence.metamodel.Type;
 import jakarta.persistence.sql.ConstructorMapping;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
@@ -99,6 +99,11 @@ public class Client3 extends PMClientBase {
 		}
 	}
 
+	@Override
+	protected Map<String, Object> extraPersistenceUnitProperties() {
+		return storedProceduresExtraProperties();
+	}
+
 	public List<List> getResultSetsFromStoredProcedure(StoredProcedureQuery spq) {
 		logger.log(Logger.Level.TRACE, "in getResultSetsFromStoredProcedure");
 		boolean results = true;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
@@ -100,6 +100,11 @@ public class Client extends PMClientBase {
 		}
 	}
 
+	@Override
+	protected Map<String, Object> extraPersistenceUnitProperties() {
+		return storedProceduresExtraProperties();
+	}
+
 	/*
 	 * @testName: createStoredProcedureQueryStringTest
 	 * 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
@@ -97,6 +97,11 @@ public class Client extends PMClientBase {
 		}
 	}
 
+	@Override
+	protected Map<String, Object> extraPersistenceUnitProperties() {
+		return storedProceduresExtraProperties();
+	}
+
 	/*
 	 * @testName: persistAfterClose
 	 * 


### PR DESCRIPTION
Calls to stored procedures were actually scattered among different test files. So the first run, depending on the order, may cause tests to fail if procedures haven't been created yet. 😖 
This patch adds procedures to the test files that call them, so the order should no longer matter.