### PR TITLE
make TypedQueryReference.getResultType() nullable

### DIFF
--- a/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
+++ b/api/src/main/java/jakarta/persistence/EntityManagerFactory.java
@@ -507,8 +507,8 @@ public interface EntityManagerFactory extends AutoCloseable {
 
     /**
      * A map keyed by {@linkplain NamedQuery#name query name}, containing
-     * {@linkplain TypedQueryReference references} to every named query whose
-     * result type is assignable to the given Java type.
+     * {@linkplain TypedQueryReference references} to every named query
+     * whose result type is assignable to the given Java type.
      * @param resultType any Java type, including {@code Object.class}
      *                   meaning all queries
      * @return a map keyed by query name

--- a/api/src/main/java/jakarta/persistence/TypedQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/TypedQueryReference.java
@@ -105,10 +105,10 @@ public non-sealed interface TypedQueryReference<R> extends Reference {
      * {@link jakarta.persistence.query.NativeQuery}.
      *
      * @return The result type as a Java {@link Class} object,
-     *         or {@code void.class} when the result type is
-     *         not explicitly specified and cannot be inferred.
+     *         or {@code null} when the result type is not
+     *         explicitly specified and cannot be inferred.
      */
-    @Nonnull
+    @Nullable
     Class<? extends R> getResultType();
 
     /**

--- a/api/src/main/java/jakarta/persistence/query/StaticTypedQueryReference.java
+++ b/api/src/main/java/jakarta/persistence/query/StaticTypedQueryReference.java
@@ -44,7 +44,7 @@ public class StaticTypedQueryReference<R>
 
     @Nonnull private final Class<?> annotatedClass;
     @Nonnull private final String annotatedMemberName;
-    @Nonnull private final Class<R> resultType;
+    @Nullable private final Class<R> resultType;
     @Nonnull private final String name;
     @Nonnull private final List<Class<?>> parameterTypes;
     @Nonnull private final List<String> parameterNames;
@@ -80,7 +80,7 @@ public class StaticTypedQueryReference<R>
             @Nonnull String queryName,
             @Nonnull Class<?> annotatedClass,
             @Nonnull String annotatedMemberName,
-            @Nonnull Class<R> resultType,
+            @Nullable Class<R> resultType,
             @Nonnull List<Class<?>> parameterTypes,
             @Nonnull List<String> parameterNames,
             @Nonnull List<Object> arguments,
@@ -139,8 +139,8 @@ public class StaticTypedQueryReference<R>
     }
 
     @Override
-    @Nonnull
-    public Class<? extends R> getResultType() {
+    @Nullable
+    public Class<R> getResultType() {
         return resultType;
     }
 


### PR DESCRIPTION
Using void.class turns out to make this harder not easier to implement.

This just rolls back a previous recent change.