### PR TITLE
Consistently use EntityManagerFactory.getSchemaManager().truncate() for data cleanup between tests

### DIFF
--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -174,13 +174,16 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
         super();
     }
 
-    protected void removeEntity(Object o) {
-        if (o != null) {
-            try {
-                getEntityManager().remove(o);
-            } catch (Exception e) {
-                logger.log(Logger.Level.ERROR, "removeEntity: Exception caught when removing entity: ", e);
-            }
+    protected void removeTestData() {
+        logger.log(Logger.Level.TRACE, "removeTestData");
+        if (getEntityTransaction().isActive()) {
+            getEntityTransaction().rollback();
+        }
+        try {
+            getEntityManagerFactory().getSchemaManager().truncate();
+            getEntityManager().clear();
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
         }
     }
 

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/Util.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/Util.java
@@ -1847,51 +1847,6 @@ public abstract class Util extends PMClientBase {
 		}
 	}
 
-	public void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM FKS_ANOOP_CNOOP").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM FKS_ALIAS_CUSTOMER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ALIAS_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CREDITCARD_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM SPOUSE_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INFO_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONE_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("UPDATE ORDER_TABLE SET FK4_FOR_CUSTOMER_TABLE= NULL").executeUpdate();
-			getEntityManager()
-					.createNativeQuery("UPDATE LINEITEM_TABLE SET FK_FOR_PRODUCT_TABLE= NULL, FK1_FOR_ORDER_TABLE=NULL")
-					.executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUSTOMER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_DETAILS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM TRIM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM A_BASIC").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CRITERIA_TEST_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-			logger.log(Logger.Level.TRACE, "done removeTestData");
-
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 	public abstract JavaArchive createDeployment() throws Exception;
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/Client.java
@@ -645,27 +645,4 @@ public class Client extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
@@ -193,26 +193,4 @@ public class Client extends PMClientBase {
 		}
 		return result;
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
@@ -2348,9 +2348,7 @@ public class Client1 extends Client {
         boolean pass1 = false;
         boolean pass2 = false;
 
-        try {
-
-            StoredProcedureQuery spq = getEntityManager().createNamedStoredProcedureQuery("tobeoverridden1");
+        try (StoredProcedureQuery spq = getEntityManager().createNamedStoredProcedureQuery("tobeoverridden1")) {
             spq.setParameter(1, 1);
             Object o = spq.getParameterValue(1);
             if (o instanceof Integer) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client.java
@@ -46,28 +46,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "isActive:" + getEntityTransaction().isActive());
-			getEntityManager().createNativeQuery("Delete from DATATYPES").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/Client.java
@@ -209,28 +209,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from PARTTIMEEMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client.java
@@ -44,27 +44,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from DATATYPES").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/Client.java
@@ -168,28 +168,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from PARTTIMEEMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from ADDRESS").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client.java
@@ -93,26 +93,4 @@ public class Client extends PMClientBase {
 		}
 
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BASIC").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/Client.java
@@ -173,27 +173,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from COLTAB_ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COLTAB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/convert/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/convert/Client.java
@@ -743,31 +743,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM B_EMBEDDABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/Client.java
@@ -188,27 +188,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE_DISCRIMINATOR").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/Client.java
@@ -174,26 +174,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from B_EMBEDDABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/Client.java
@@ -174,27 +174,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from COLTAB_EMP_EMBEDED_ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE_EMBEDED_ADDRESS").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/Client.java
@@ -256,26 +256,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COFFEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/Client.java
@@ -731,29 +731,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BASIC").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES3").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/Client.java
@@ -208,26 +208,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client.java
@@ -145,27 +145,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in RemoveSchemaData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/Client.java
@@ -179,29 +179,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from ENROLLMENTS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from SEMESTER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from STUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COURSE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in RemoveSchemaData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
@@ -582,28 +582,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMP_MAPKEYCOL").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
@@ -630,32 +630,6 @@ public class Client extends PMClientBase {
 	 * super.cleanup(); }
 	 */
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMP_MAPKEYCOL").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from EMP_MAPKEYCOL2").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 	/*
 	 * private void removeCustTestData() {
 	 * logger.log(Logger.Level.TRACE,"removeCustTestData"); if

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/Client.java
@@ -274,30 +274,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from ENROLLMENTS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from SEMESTER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from STUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COURSE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/Client.java
@@ -495,30 +495,6 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMP_MAPKEYCOL2").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 	private void removeCustTestData() {
 		logger.log(Logger.Level.TRACE, "removeCustTestData");
 		if (getEntityTransaction().isActive()) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/Client.java
@@ -149,27 +149,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from DID1BDEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DID1BEMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/Client.java
@@ -949,30 +949,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete FROM ORDER2").executeUpdate();
-			getEntityManager().createNativeQuery("Delete FROM ORDER1").executeUpdate();
-			getEntityManager().createNativeQuery("Delete FROM ITEM").executeUpdate();
-			getEntityManager().createNativeQuery("Delete FROM PURCHASE_ORDER").executeUpdate();
-
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/Client.java
@@ -157,27 +157,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from CUSTOMER1").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from RETAILORDER2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1.java
@@ -455,28 +455,4 @@ public class Client1 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from INSURANCE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1.java
@@ -266,28 +266,4 @@ public class Client1 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from COURSE_STUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from STUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COURSE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client.java
@@ -41,26 +41,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/Client.java
@@ -361,28 +361,4 @@ public class Client extends PMClientBase {
 		}
 
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BASIC").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATE_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATES_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client.java
@@ -40,26 +40,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BASIC").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/Client.java
@@ -160,26 +160,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/Client.java
@@ -379,26 +379,4 @@ public class Client extends PMClientBase {
 		}
 
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/added/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/added/Client.java
@@ -336,26 +336,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/Client.java
@@ -476,27 +476,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRICED_PRODUCT_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/Client.java
@@ -577,28 +577,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/Client.java
@@ -569,28 +569,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/Client.java
@@ -583,28 +583,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/Client.java
@@ -577,28 +577,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
@@ -683,29 +683,4 @@ public class Client extends EntityCallbackClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LINEITEM_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ORDER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUSTOMER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/Client.java
@@ -537,27 +537,4 @@ public class Client extends UtilProductData {
 		}
 
 	}
-
-	public void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_DETAILS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/Client.java
@@ -851,27 +851,4 @@ public class Client extends UtilProductData {
 		}
 
 	}
-
-	public void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_DETAILS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client.java
@@ -81,26 +81,4 @@ public abstract class Client extends PMClientBase {
 			}
 		}
 	}
-
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/Client.java
@@ -139,27 +139,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID1DEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID1EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/Client.java
@@ -136,27 +136,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID1BDEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID1BEMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/Client.java
@@ -139,27 +139,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID2DEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID2EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/Client.java
@@ -153,27 +153,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID2BDEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID2BEMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/Client.java
@@ -139,27 +139,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID3DEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID3EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/Client.java
@@ -168,27 +168,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID3BDEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID3BEMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/Client.java
@@ -128,27 +128,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID4MEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID4PERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/Client.java
@@ -130,27 +130,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID4BMEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID4BPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/Client.java
@@ -131,27 +131,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID5MEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID5PERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/Client.java
@@ -151,27 +151,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID5BMEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID5BPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/Client.java
@@ -132,27 +132,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID6MEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID6PERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/Client.java
@@ -151,27 +151,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID6BMEDICALHISTORY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID6BPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
@@ -533,27 +533,4 @@ public class Client2 extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
@@ -454,27 +454,4 @@ public class Client3 extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
@@ -215,7 +215,7 @@ public class Client2 extends PMClientBase {
 			getEntityTransaction().begin();
 			Order o = getEntityManager().find(Order.class, 4);
 			getEntityTransaction().commit();
-			removeTestData();
+			truncateTestData();
 			getEntityManager().lock(o, LockModeType.PESSIMISTIC_READ);
 			logger.log(Logger.Level.ERROR, "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {
@@ -239,7 +239,7 @@ public class Client2 extends PMClientBase {
 			getEntityTransaction().begin();
 			Order o = getEntityManager().find(Order.class, 4);
 			getEntityTransaction().commit();
-			removeTestData();
+			truncateTestData();
 			getEntityManager().lock(o, LockModeType.PESSIMISTIC_READ, myMap);
 			logger.log(Logger.Level.ERROR, "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {
@@ -290,7 +290,7 @@ public class Client2 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
+	protected void truncateTestData() {
 		logger.log(Logger.Level.TRACE, "removeTestData");
 		if (getEntityTransaction().isActive()) {
 			getEntityTransaction().rollback();
@@ -299,14 +299,6 @@ public class Client2 extends PMClientBase {
 			getEntityManagerFactory().getSchemaManager().truncate();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
 		}
 	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -346,24 +346,4 @@ public class Client3 extends PMClientBase {
             }
         }
     }
-
-    private void removeTestData() {
-        logger.log(Logger.Level.TRACE, "removeTestData");
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        try {
-            getEntityManagerFactory().getSchemaManager().truncate();
-        } catch (Exception e) {
-            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-        } finally {
-            try {
-                if (getEntityTransaction().isActive()) {
-                    getEntityTransaction().rollback();
-                }
-            } catch (Exception re) {
-                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-            }
-        }
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1.java
@@ -904,28 +904,4 @@ public class Client1 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			clearCache();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM MEMBER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3.java
@@ -419,28 +419,4 @@ public class Client3 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			clearCache();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM MEMBER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/Client.java
@@ -984,26 +984,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COFFEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/Client.java
@@ -544,26 +544,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BIGDECIMAL").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/Client.java
@@ -543,26 +543,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM A_BIGINTEGER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/Client.java
@@ -778,28 +778,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM FKEYS_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/Client.java
@@ -639,27 +639,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/Client.java
@@ -770,27 +770,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/Client.java
@@ -697,27 +697,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/Client.java
@@ -219,26 +219,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/Client.java
@@ -193,28 +193,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM FKEYS_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/Client.java
@@ -162,27 +162,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/Client.java
@@ -255,27 +255,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/Client.java
@@ -231,27 +231,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/Client.java
@@ -399,26 +399,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/Client.java
@@ -804,28 +804,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM FKEYS_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MXM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/Client.java
@@ -673,27 +673,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_MX1_UNI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/Client.java
@@ -959,28 +959,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			clearCache();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/Client.java
@@ -760,27 +760,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/Client.java
@@ -401,26 +401,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/Client.java
@@ -636,27 +636,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/Client.java
@@ -621,27 +621,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/Client.java
@@ -268,26 +268,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/exceptions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/exceptions/Client.java
@@ -1728,26 +1728,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COFFEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/Client.java
@@ -291,26 +291,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/Client.java
@@ -214,27 +214,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PARTTIMEEMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/Client.java
@@ -214,26 +214,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Client.java
@@ -280,26 +280,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/entitymanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/entitymanager/Client.java
@@ -649,27 +649,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COFFEE").executeUpdate();
-
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/query/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/query/Client.java
@@ -777,28 +777,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/Client.java
@@ -364,11 +364,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/Client.java
@@ -160,11 +160,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/Client.java
@@ -150,11 +150,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/Client.java
@@ -2530,11 +2530,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/Client.java
@@ -812,11 +812,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
@@ -3073,11 +3073,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/Client.java
@@ -293,17 +293,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		try {
-			if (getEntityTransaction().isActive()) {
-				getEntityTransaction().rollback();
-			}
-		} catch (Exception re) {
-			logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/Client.java
@@ -2852,11 +2852,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/Client.java
@@ -257,11 +257,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/Client.java
@@ -769,11 +769,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/Client.java
@@ -502,11 +502,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/Client.java
@@ -535,17 +535,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		try {
-			if (getEntityTransaction().isActive()) {
-				getEntityTransaction().rollback();
-			}
-		} catch (Exception re) {
-			logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/Client.java
@@ -189,11 +189,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/Client.java
@@ -630,11 +630,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/Client.java
@@ -177,11 +177,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/Client.java
@@ -445,27 +445,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM ANE_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BNE_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/Client.java
@@ -113,26 +113,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM LAWBOOK").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/Client.java
@@ -239,26 +239,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM NOENTITYLISTENER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/Client.java
@@ -283,30 +283,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BOOK").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM COMPLAINT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM MOVIETICKET").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BOOKSTORE").executeUpdate();
-
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/Client.java
@@ -222,27 +222,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM NAMEONLYINXML").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM NOENTITYANNOTATION").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/Client.java
@@ -231,26 +231,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM NOENTITYLISTENER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/Client.java
@@ -404,35 +404,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COURSE_2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUBICLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUSTOMER1").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_ORDER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM HARDWARE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM RETAILORDER1").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM STUDENT_2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM STUDENT_2_COURSE_2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM THEATRECOMPANY1").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM THEATRELOCATION1").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/Client.java
@@ -158,28 +158,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COURSE_2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM STUDENT_2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/Client.java
@@ -427,36 +427,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from  DEPARTMENT_2").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE_2").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  STORE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  CUSTOMERS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  THEATRELOCATION_THEATRECOMPANY").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  RETAILORDER_CONSUMER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  RETAILORDER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  CONSUMER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  THEATRELOCATION").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from  THEATRECOMPANY").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/Client.java
@@ -184,26 +184,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM NOENTITYLISTENER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/Client.java
@@ -94,26 +94,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM NOENTITYLISTENER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -320,27 +320,4 @@ public class Client extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM MEMBER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/Client.java
@@ -90,26 +90,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
@@ -4374,30 +4374,4 @@ public class Client1 extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3.java
@@ -320,30 +320,4 @@ public class Client3 extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4.java
@@ -436,30 +436,4 @@ public class Client4 extends PMClientBase {
         }
 
     }
-
-    private void removeTestData() {
-        logger.log(Logger.Level.TRACE, "removeTestData");
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        try {
-            getEntityTransaction().begin();
-            getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-            getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-            getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-            getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-            getEntityTransaction().commit();
-        } catch (Exception e) {
-            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-        } finally {
-            try {
-                if (getEntityTransaction().isActive()) {
-                    getEntityTransaction().rollback();
-                }
-            } catch (Exception re) {
-                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-            }
-        }
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2.java
@@ -253,27 +253,4 @@ public class Client2 extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Client.java
@@ -1296,35 +1296,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT_PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM TEAM").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM COMPANY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ADDRESS").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/Client.java
@@ -184,28 +184,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIRMXMPERSON_BIDIRMXMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIRMXMPERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIRMXMPROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/Client.java
@@ -168,27 +168,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIRMX1PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIRMX1PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/Client.java
@@ -205,27 +205,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIR1XMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIR1XMPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/Client.java
@@ -130,27 +130,4 @@ public class Client extends PMClientBase {
 		}
 
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIR1X1PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BIDIR1X1PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Client.java
@@ -1192,35 +1192,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM TEAM").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM COMPANY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT_PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/Client.java
@@ -1195,35 +1195,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON_ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ANNUALREVIEW").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM TEAM").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM COMPANY").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT_PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/Client.java
@@ -173,28 +173,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM UNIMXMPERSON_UNIMXMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNIMXMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNIMXMPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/Client.java
@@ -156,27 +156,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM UNIMX1PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNIMX1PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/Client.java
@@ -146,28 +146,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM UNI1XMPERSON_UNI1XMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNI1XMPROJECT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNI1XMPERSON").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/Client.java
@@ -116,27 +116,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM UNI1X1PERSON").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UNI1X1PROJECT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/Client.java
@@ -502,26 +502,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/Client.java
@@ -1253,28 +1253,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM UUIDTYPE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client.java
@@ -58,26 +58,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	protected void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/Client.java
@@ -350,26 +350,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PKEY").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1.java
@@ -939,27 +939,4 @@ public class Client1 extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/Client.java
@@ -168,26 +168,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM MEMBER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/Client.java
@@ -1041,28 +1041,4 @@ public class Client extends PMClientBase {
 		}
 
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			clearCache();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1XM_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/Client.java
@@ -124,26 +124,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/Client.java
@@ -96,16 +96,16 @@ public class Client extends PMClientBase {
 		assertTrue(ids.size() == 21, "Unexpected result count:" + ids.size());
 		assertTrue(checkEntityPK(ids, expected, false), "Unexpected PKs received");
 
-		Stream<?> s1 = query.getResultStream();
-		try {
+		try (Stream<?> s1 = query.getResultStream()) {
 			s1.forEach(this::checkPK);
 		} catch (RuntimeException e) {
 			throw new Exception(e.getMessage());
 		}
 
 		ObjectCounter oc = new ObjectCounter();
-		s1 = query.getResultStream();
-		s1.forEach(oc::increment);
+		try (Stream<?> s1 = query.getResultStream()) {
+			s1.forEach(oc::increment);
+		}
 		assertTrue(oc.getCounter() == 21, "Unexpected streamed objects found:" + oc.getCounter());
 		logger.log(Logger.Level.TRACE, "Query.getResultStream() returned expected ids");
 	}
@@ -127,16 +127,16 @@ public class Client extends PMClientBase {
 		assertTrue(received.size() == 21, "Unexpected result count:" + received.size());
 		assertTrue(checkEntityPK(received, expected, false), "Unexpected PKs received");
 
-		Stream<Employee> s1 = query.getResultStream();
-		try {
+		try (Stream<Employee> s1 = query.getResultStream()) {
 			s1.forEach(this::checkPK);
 		} catch (RuntimeException e) {
 			throw new Exception(e.getMessage());
 		}
 
 		ObjectCounter oc = new ObjectCounter();
-		s1 = query.getResultStream();
-		s1.forEach(oc::increment);
+		try (Stream<Employee> s1 = query.getResultStream()) {
+			s1.forEach(oc::increment);
+		}
 		assertTrue(oc.getCounter() == 21, "Unexpected streamed objects found:" + oc.getCounter());
 		logger.log(Logger.Level.TRACE, "TypedQuery.getResultStream() returned expected ids");
 	}
@@ -320,32 +320,6 @@ public class Client extends PMClientBase {
 			super.cleanup();
 		} finally {
 			removeTestJarFromCP();
-		}
-	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM INSURANCE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATATYPES2").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/Client.java
@@ -202,28 +202,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from PARTTIMEEMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/convert/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/convert/Client.java
@@ -135,31 +135,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM B_EMBEDDABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/Client.java
@@ -140,27 +140,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM DID2DEPENDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DID2EMPLOYEE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/Client.java
@@ -267,30 +267,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from ENROLLMENTS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from SEMESTER").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from STUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COURSE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/Client.java
@@ -230,27 +230,4 @@ public class Client extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/Client.java
@@ -155,29 +155,6 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM COFFEE").executeUpdate();
-
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 	private void assertTrue(boolean b, String message) throws Exception {
 		if (!b)
 			throw new Exception(message);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
@@ -337,29 +337,6 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 	private List<List<Employee>> getResultSetsFromStoredProcedure(StoredProcedureQuery spq) {
 		logger.log(Logger.Level.TRACE, "in getResultSetsFromStoredProcedure");
 		boolean results = true;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/generators/sequencegenerators/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/generators/sequencegenerators/Client.java
@@ -244,33 +244,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/repeatable/secondarytable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/repeatable/secondarytable/Client.java
@@ -165,27 +165,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_DETAILS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
@@ -125,13 +125,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
@@ -143,13 +143,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
@@ -175,13 +175,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
@@ -103,13 +103,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
@@ -104,13 +104,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
@@ -85,13 +85,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
@@ -80,13 +80,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
@@ -118,13 +118,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
@@ -103,12 +103,4 @@ public class Client extends PMClientBase {
         assertEquals(GraphAdvancedStaffAuthor.class, keyGraph.getClassType());
         assertTrue(keyGraph.hasAttributeNode("department"));
     }
-
-    private void removeTestData() {
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
@@ -137,13 +137,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
@@ -145,13 +145,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
@@ -85,13 +85,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
@@ -110,13 +110,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/recordpk/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/recordpk/Client.java
@@ -86,13 +86,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
@@ -74,13 +74,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
@@ -97,13 +97,4 @@ public class Client extends PMClientBase {
                 .createQuery("SELECT COUNT(e) FROM Jpa32SchemaManagedEntity e", Long.class)
                 .getSingleResult();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
@@ -93,13 +93,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
@@ -80,13 +80,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
@@ -67,13 +67,4 @@ public class Client extends PMClientBase {
         transaction.setTimeout(null);
         assertNull(transaction.getTimeout());
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
@@ -72,13 +72,4 @@ public class Client extends PMClientBase {
         assertEquals(entity.getId(), UuidPrePersistEntity.getPrePersistId());
         transaction.commit();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
@@ -86,13 +86,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
@@ -82,13 +82,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/callbacks/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/callbacks/Client.java
@@ -290,15 +290,6 @@ public class Client extends PMClientBase {
         assertEquals(0L, countCallbackEntities());
     }
 
-    private void removeTestData() {
-        var transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
-
     private void createCallbackEntity(CallbackEntity entity) {
         var transaction = getEntityTransaction();
         transaction.begin();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
@@ -491,13 +491,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteriastring/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteriastring/Client.java
@@ -328,13 +328,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/emflistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/emflistener/Client.java
@@ -87,13 +87,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
@@ -431,15 +431,6 @@ public class Client extends PMClientBase {
         assertEquals(List.of("updated before bulk upsert", "second"), titlesById(1, 2));
     }
 
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
-
     private long countBooks() {
         return getEntityManagerFactory().callInTransaction(entityManager -> entityManager
                 .createQuery("SELECT COUNT(b) FROM Jpa40AgentBook b", Long.class)

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entitytypegraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entitytypegraph/Client.java
@@ -83,13 +83,4 @@ public class Client extends PMClientBase {
                 namedGraphs.get(EntityTypeGraphBook.GRAPH).getGraphedType().getJavaType());
         assertTrue(namedGraphs.get(EntityTypeGraphBook.GRAPH).hasAttributeNode("title"));
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
@@ -197,13 +197,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/find/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/find/Client.java
@@ -334,15 +334,6 @@ public class Client extends PMClientBase {
         getEntityManager().clear();
     }
 
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
-
     private void assertOrderedFindMultipleResults(List<AccessBook> books) {
         assertEquals(3, books.size());
         assertEquals(1, books.get(0).getId());

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/jpql/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/jpql/Client.java
@@ -105,13 +105,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/lockscope/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/lockscope/Client.java
@@ -149,13 +149,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nameddescriptor/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nameddescriptor/Client.java
@@ -95,13 +95,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/Client.java
@@ -161,13 +161,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/SharedNameClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/SharedNameClient.java
@@ -118,13 +118,4 @@ public class SharedNameClient extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedqueryregistration/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedqueryregistration/Client.java
@@ -166,13 +166,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nonnull/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nonnull/Client.java
@@ -74,13 +74,4 @@ public class Client extends PMClientBase {
         assertFalse(title.isOptional());
         assertTrue(subtitle.isOptional());
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/parameters/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/parameters/Client.java
@@ -273,13 +273,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/queryflush/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/queryflush/Client.java
@@ -154,13 +154,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/querygraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/querygraph/Client.java
@@ -178,13 +178,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        var transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/resultcount/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/resultcount/Client.java
@@ -81,13 +81,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/schemamanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/schemamanager/Client.java
@@ -111,15 +111,6 @@ public class Client extends PMClientBase {
         }
     }
 
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
-
     private long countBooks(EntityManagerFactory emf) {
         return emf.callInTransaction(entityManager -> entityManager
                 .createQuery("SELECT COUNT(b) FROM Jpa40SchemaPopulateBook b", Long.class)

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/sqlresultmapping/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/sqlresultmapping/Client.java
@@ -310,13 +310,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/statement/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/statement/Client.java
@@ -204,13 +204,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/versioning/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/versioning/Client.java
@@ -91,13 +91,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/xmlstatement/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/xmlstatement/Client.java
@@ -92,13 +92,4 @@ public class Client extends PMClientBase {
         transaction.commit();
         getEntityManager().clear();
     }
-
-    private void removeTestData() {
-        EntityTransaction transaction = getEntityTransaction();
-        if (transaction.isActive()) {
-            transaction.rollback();
-        }
-        getEntityManagerFactory().getSchemaManager().truncate();
-        getEntityManager().clear();
-    }
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/inherit/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/inherit/Client.java
@@ -258,27 +258,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_DETAILS").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PRODUCT_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/all/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/all/Client.java
@@ -636,26 +636,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/disableselective/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/disableselective/Client.java
@@ -146,27 +146,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUSTOMER_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/enableselective/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/enableselective/Client.java
@@ -159,28 +159,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM CUSTOMER_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/none/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/none/Client.java
@@ -128,26 +128,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/descriptor/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/descriptor/Client.java
@@ -129,27 +129,4 @@ public class Client extends PMClientBase {
 			removeTestJarFromCP();
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
@@ -4032,27 +4032,4 @@ public class Client extends PMClientBase {
 			}
 		}
 	}
-
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client1.java
@@ -821,31 +821,4 @@ public class Client1 extends PMClientBase {
 		removeTestJarFromCP();
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityManager().isOpen()) {
-			if (getEntityTransaction().isActive()) {
-				getEntityTransaction().rollback();
-			}
-			try {
-				getEntityTransaction().begin();
-				getEntityManager().createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
-				getEntityManager().createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
-				getEntityTransaction().commit();
-			} catch (Exception e) {
-				logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-			} finally {
-				try {
-					if (getEntityTransaction().isActive()) {
-						getEntityTransaction().rollback();
-					}
-				} catch (Exception re) {
-					logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-				}
-			}
-		} else {
-			logger.log(Logger.Level.TRACE, "EntityManager is closed. No need to remove data");
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/discriminatorColumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/discriminatorColumn/Client.java
@@ -219,33 +219,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/enumerated/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/enumerated/Client.java
@@ -218,33 +218,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/id/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/id/Client.java
@@ -218,33 +218,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/index/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/index/Client.java
@@ -301,33 +301,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/joinTable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/joinTable/Client.java
@@ -354,34 +354,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENCOURSE").executeUpdate();
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSTUDENT").executeUpdate();
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGEN_COURSE_STUDENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROPS, IT MAY OR MAY NOT BE A PROBLEM, " + t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/orderColumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/orderColumn/Client.java
@@ -300,33 +300,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENEMP").executeUpdate();
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENDEPT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE, IT MAY OR MAY NOT BE A PROBLEM, " + t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/secondaryTable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/secondaryTable/Client.java
@@ -256,33 +256,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/sequenceGenerator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/sequenceGenerator/Client.java
@@ -248,33 +248,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/table/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/table/Client.java
@@ -213,33 +213,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/temporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/temporal/Client.java
@@ -222,33 +222,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/uniqueConstraint/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/uniqueConstraint/Client.java
@@ -239,33 +239,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/version/Client.java
@@ -220,33 +220,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/scripts/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/scripts/Client.java
@@ -1133,33 +1133,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	private void removeTestData() {
-		logger.log(Logger.Level.TRACE, "removeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			logger.log(Logger.Level.INFO, "Try to drop table SCHEMAGENSIMPLE");
-			getEntityManager().createNativeQuery("DROP TABLE SCHEMAGENSIMPLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Throwable t) {
-			logger.log(Logger.Level.INFO,
-					"AN EXCEPTION WAS THROWN DURING DROP TABLE SCHEMAGENSIMPLE, IT MAY OR MAY NOT BE A PROBLEM, "
-							+ t.getMessage());
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-				clearEntityTransaction();
-
-				// ensure that we close the EM and EMF before proceeding.
-				clearEMAndEMF();
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
@@ -164,26 +164,4 @@ public class Client1 extends PMClientBase {
         }
     }
 
-    private void removeTestData() {
-        logger.log(Logger.Level.TRACE, "removeTestData");
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        try {
-            getEntityTransaction().begin();
-            getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-            getEntityTransaction().commit();
-        } catch (Exception e) {
-            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-        } finally {
-            try {
-                if (getEntityTransaction().isActive()) {
-                    getEntityTransaction().rollback();
-                }
-            } catch (Exception re) {
-                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-            }
-        }
-    }
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
@@ -253,26 +253,4 @@ public class Client2 extends PMClientBase {
         }
     }
 
-    private void removeTestData() {
-        logger.log(Logger.Level.TRACE, "removeTestData");
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        try {
-            getEntityTransaction().begin();
-            getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-            getEntityTransaction().commit();
-        } catch (Exception e) {
-            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-        } finally {
-            try {
-                if (getEntityTransaction().isActive()) {
-                    getEntityTransaction().rollback();
-                }
-            } catch (Exception re) {
-                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-            }
-        }
-    }
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
@@ -226,26 +226,4 @@ public class Client3 extends PMClientBase {
     }
 
 
-    private void removeTestData() {
-        logger.log(Logger.Level.TRACE, "removeTestData");
-        if (getEntityTransaction().isActive()) {
-            getEntityTransaction().rollback();
-        }
-        try {
-            getEntityTransaction().begin();
-            getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
-            getEntityTransaction().commit();
-        } catch (Exception e) {
-            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-        } finally {
-            try {
-                if (getEntityTransaction().isActive()) {
-                    getEntityTransaction().rollback();
-                }
-            } catch (Exception re) {
-                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
We were using this pattern of "within transaction execute a bunch of delete queries" to clean up data between tests. But then @sebersole pointed to exceptions logged in the execution that the table is missing for some of the tests ....

since in the past the schema was created upfront it wasn't an issue that we were just running delete statements, even if the entity wasn't involved in the current test...

With the change where tests create the schema themselves, it makes more sense to just go with `truncate()` ... 

(And as a "bonus", this actually uncovered a few more things in ORM)