### PR TITLE
Switch to TestInstance.Lifecycle.PER_CLASS / Fix flaky tests for date-time / remove individual cleanup methods

### DIFF
--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/DriverManagerConnection.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/DriverManagerConnection.java
@@ -23,7 +23,7 @@ import java.util.Properties;
 
 public class DriverManagerConnection {
 
-	private static final Logger logger = (Logger) System.getLogger(DriverManagerConnection.class.getName());
+	private static final Logger logger = System.getLogger(DriverManagerConnection.class.getName());
 
 	public Connection getConnection(Properties p) throws Exception {
 		String dbUrl, dbUser, dbPassword, dbDriver;

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -76,11 +76,13 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceException;
 
+import org.junit.jupiter.api.AfterEach;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 abstract public class PMClientBase implements UseEntityManager, UseEntityManagerFactory, java.io.Serializable {
 
-    private static final Logger logger = (Logger) System.getLogger(PMClientBase.class.getName());
+    private static final Logger logger = System.getLogger(PMClientBase.class.getName());
 
     protected Properties myProps = new Properties();
 
@@ -180,8 +182,10 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
             getEntityTransaction().rollback();
         }
         try {
-            getEntityManagerFactory().getSchemaManager().truncate();
-            getEntityManager().clear();
+            final var entityManagerFactory = getEntityManagerFactory();
+            if (entityManagerFactory != null) {
+                entityManagerFactory.getSchemaManager().truncate();
+            }
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
         }
@@ -260,11 +264,15 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
     /**
      * In JakartaEE environment, does nothing. In Java SE environment, closes the
      * EntityManager if its open, and closes the EntityManagerFactory if its open.
-     * If a subclass overrides this method, the overriding implementation must call
-     * super.cleanup() at the end. Also, the cache cleared.
+     * Also, the cache cleared.
      */
-    public void cleanup() throws Exception {
-        closeEMAndEMF();
+    @AfterEach
+    public final void cleanup() throws Exception {
+        try {
+            closeEMAndEMF();
+        } finally {
+            removeTestJarFromCP();
+        }
     }
 
     /*
@@ -301,6 +309,7 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
             }
 
             if (getEntityManagerFactory() != null && getEntityManagerFactory().isOpen()) {
+                removeTestData();
                 getEntityManagerFactory().close();
             }
         }

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -76,10 +76,13 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceException;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestInstance;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract public class PMClientBase implements UseEntityManager, UseEntityManagerFactory, java.io.Serializable {
 
     private static final Logger logger = System.getLogger(PMClientBase.class.getName());
@@ -208,6 +211,7 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
      */
     public void setup() throws Exception {
         logger.log(Logger.Level.TRACE, "PMClientBase.setup");
+        myProps.clear();
         mode = System.getProperty(MODE_PROP);
         myProps.put(MODE_PROP, mode);
         persistenceUnitName = System.getProperty(PERSISTENCE_UNIT_NAME_PROP);
@@ -269,7 +273,42 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
     @AfterEach
     public final void cleanup() throws Exception {
         try {
-            closeEMAndEMF();
+            logger.log(Logger.Level.TRACE,
+                    "Rolling back any existing transaction before closing EM if one exists.");
+            if (getEntityTransaction(false) != null && getEntityTransaction(false).isActive()) {
+                logger.log(Logger.Level.TRACE, "An active transaction was found, rolling it back.");
+                getEntityTransaction(false).rollback();
+            }
+        } catch (Exception fe) {
+            logger.log(Logger.Level.INFO, "Unexpected exception rolling back TX:", fe);
+        }
+
+        clearCache();
+
+        if (isStandAloneMode()) {
+            logger.log(Logger.Level.TRACE, "Closing EM and truncating data");
+            if (em != null && em.isOpen()) {
+                em.close();
+            }
+            this.em = null;
+            this.et = null;
+
+            if (emf != null && emf.isOpen()) {
+                try {
+                    emf.getSchemaManager().truncate();
+                } catch (Exception e) {
+                    logger.log(Logger.Level.ERROR, "Exception encountered while truncating schema:", e);
+                }
+            }
+        }
+    }
+
+    @AfterAll
+    public void cleanupAll() throws Exception {
+        try {
+            if (isStandAloneMode() && emf != null && emf.isOpen()) {
+                emf.close();
+            }
         } finally {
             removeTestJarFromCP();
         }
@@ -496,17 +535,19 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
     protected void initEntityManager(String persistenceUnitName, boolean useProps) {
         if (isStandAloneMode()) {
             logger.log(Logger.Level.TRACE, "in initEntityManager(String, boolean): " + persistenceUnitName);
-            if (useProps) {
-                Properties propsMap = getPersistenceUnitProperties();
-                logger.log(Logger.Level.TRACE, "createEntityManagerFactory(String,Map)");
-                emf = Persistence.createEntityManagerFactory(persistenceUnitName, propsMap);
-            } else {
-                logger.log(Logger.Level.TRACE, "createEntityManagerFactory(String)");
-                emf = Persistence.createEntityManagerFactory(persistenceUnitName);
-            }
-            Map<java.lang.String, java.lang.Object> emfMap = emf.getProperties();
-            if (emfMap != null) {
-                displayMap(emfMap);
+            if (emf == null || !emf.isOpen()) {
+                if (useProps) {
+                    Properties propsMap = getPersistenceUnitProperties();
+                    logger.log(Logger.Level.TRACE, "createEntityManagerFactory(String,Map)");
+                    emf = Persistence.createEntityManagerFactory(persistenceUnitName, propsMap);
+                } else {
+                    logger.log(Logger.Level.TRACE, "createEntityManagerFactory(String)");
+                    emf = Persistence.createEntityManagerFactory(persistenceUnitName);
+                }
+                Map<java.lang.String, java.lang.Object> emfMap = emf.getProperties();
+                if (emfMap != null) {
+                    displayMap(emfMap);
+                }
             }
             this.em = emf.createEntityManager();
         } else {
@@ -1184,7 +1225,7 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
             }
         }
 
-        if (STANDALONE_MODE.equalsIgnoreCase(mode)) {
+        if (STANDALONE_MODE.equalsIgnoreCase(mode) && !testArtifactDeployed) {
             archive.as(ZipExporter.class).exportTo(new File(TEMP_DIR + File.separator + jarName), true);
             ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
             URLClassLoader urlClassLoader = new URLClassLoader(

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -1226,10 +1226,11 @@ abstract public class PMClientBase implements UseEntityManager, UseEntityManager
     protected Map<String, Object> storedProceduresExtraProperties() {
         assertTrue(Objects.toString(myProps.get(JAKARTA_PERSISTENCE_JDBC_DRIVER), "").toLowerCase(Locale.ROOT).contains("postgresql"),
                 "This test only contains procedures for the PostgreSQL database. Running on other DBs may result in an unpredictable outcome.");
-        return Map.of(Persistence.SchemaManagementProperties.SCHEMAGEN_CREATE_SCRIPT_SOURCE,
+        return Map.of(
+                Persistence.SchemaManagementProperties.SCHEMAGEN_CREATE_SOURCE, "metadata-then-script",
+                Persistence.SchemaManagementProperties.SCHEMAGEN_CREATE_SCRIPT_SOURCE,
                 new StringReader(
-                        "CREATE TABLE IF NOT EXISTS EMPLOYEE (HIREDATE date, ID integer not null, SALARY float4, FIRSTNAME varchar(255), LASTNAME varchar(255), primary key (ID)); \n"
-                                + "CREATE OR REPLACE PROCEDURE Integer_Proc(out pmax integer, out pmin integer, out pnull integer) LANGUAGE plpgsql AS $$ BEGIN SELECT MAX_VAL, MIN_VAL, NULL_VAL INTO pmax, pmin, pnull FROM Integer_Tab; END; $$ ;\n"
+                                 "CREATE OR REPLACE PROCEDURE Integer_Proc(out pmax integer, out pmin integer, out pnull integer) LANGUAGE plpgsql AS $$ BEGIN SELECT MAX_VAL, MIN_VAL, NULL_VAL INTO pmax, pmin, pnull FROM Integer_Tab; END; $$ ;\n"
                                 + "CREATE OR REPLACE PROCEDURE GetEmpOneFirstNameFromOut(out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=1; END; $$ ;\n"
                                 + "CREATE OR REPLACE PROCEDURE GetEmpFirstNameFromOut(in IN_PARAM int, out OUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT FIRSTNAME INTO OUT_PARAM FROM EMPLOYEE WHERE ID=IN_PARAM; END; $$ ;\n"
                                 + "CREATE OR REPLACE PROCEDURE GetEmpLastNameFromInOut(inout INOUT_PARAM text) LANGUAGE plpgsql AS $$ BEGIN SELECT LASTNAME INTO INOUT_PARAM FROM EMPLOYEE WHERE ID=CAST(INOUT_PARAM AS int); END; $$ ;\n"

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/EntityManagerFactoryImpl.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/EntityManagerFactoryImpl.java
@@ -31,6 +31,7 @@ import jakarta.persistence.PersistenceUnitTransactionType;
 import jakarta.persistence.PersistenceUnitUtil;
 import jakarta.persistence.Query;
 import jakarta.persistence.SchemaManager;
+import jakarta.persistence.SchemaValidationException;
 import jakarta.persistence.Statement;
 import jakarta.persistence.StatementReference;
 import jakarta.persistence.SynchronizationType;
@@ -43,6 +44,27 @@ import jakarta.persistence.sql.ResultSetMapping;
 
 public class EntityManagerFactoryImpl implements jakarta.persistence.EntityManagerFactory {
 
+	public static final SchemaManager NOOP_SCHEMA_MANAGER = new SchemaManager() {
+		@Override
+		public void create(boolean createSchemas) {
+		}
+
+		@Override
+		public void drop(boolean dropSchemas) {
+		}
+
+		@Override
+		public void validate() throws SchemaValidationException {
+		}
+
+		@Override
+		public void truncate() {
+		}
+
+		@Override
+		public void populate() {
+		}
+	};
 	public Map properties;
 
 	public boolean isOpen;
@@ -155,7 +177,7 @@ public class EntityManagerFactoryImpl implements jakarta.persistence.EntityManag
 
 	@Override
 	public SchemaManager getSchemaManager() {
-		return null;
+		return NOOP_SCHEMA_MANAGER;
 	}
 
 	public Map<String, Object> getProperties() {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/util/LogFileProcessor.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/util/LogFileProcessor.java
@@ -64,7 +64,7 @@ public class LogFileProcessor {
 
 	private Collection appSpecificRecordCollection = null;
 
-	private static final Logger logger = (Logger) System.getLogger(LogFileProcessor.class.getName());
+	private static final Logger logger = System.getLogger(LogFileProcessor.class.getName());
 
 	public LogFileProcessor() {
 		setup();

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/Util.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/Util.java
@@ -26,13 +26,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public abstract class Util extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Util.class.getName());
+	private static final Logger logger = System.getLogger(Util.class.getName());
 
 	protected final Phone phone[] = new Phone[50];
 
@@ -98,19 +96,6 @@ public abstract class Util extends PMClientBase {
 			result.append("null");
 		}
 		return result.toString();
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 	public void createTrimData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilAliasData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilAliasData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilAliasData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilAliasData.class.getName());
+	private static final Logger logger = System.getLogger(UtilAliasData.class.getName());
 
 	@BeforeEach
 	public void setupAliasData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilAliasOnlyData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilAliasOnlyData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilAliasOnlyData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilAliasOnlyData.class.getName());
+	private static final Logger logger = System.getLogger(UtilAliasOnlyData.class.getName());
 
 	@BeforeEach
 	public void setupAliasOnlyData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCriteriaEntityData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCriteriaEntityData.java
@@ -22,7 +22,7 @@ import java.lang.System.Logger;
 
 public abstract class UtilCriteriaEntityData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilCriteriaEntityData.class.getName());
+	private static final Logger logger = System.getLogger(UtilCriteriaEntityData.class.getName());
 
 	@BeforeEach
 	public void setupCriteriaEntityData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCustAliasProductData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCustAliasProductData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilCustAliasProductData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilCustAliasProductData.class.getName());
+	private static final Logger logger = System.getLogger(UtilCustAliasProductData.class.getName());
 
 	@BeforeEach
 	public void setupCustAliasProductData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCustomerData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilCustomerData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilCustomerData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilCustomerData.class.getName());
+	private static final Logger logger = System.getLogger(UtilCustomerData.class.getName());
 
 	@BeforeEach
 	public void setupCustomerData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilDepartmentEmployeeData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilDepartmentEmployeeData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilDepartmentEmployeeData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilDepartmentEmployeeData.class.getName());
+	private static final Logger logger = System.getLogger(UtilDepartmentEmployeeData.class.getName());
 
 	@BeforeEach
 	public void setupDepartmentEmployeeData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilOrderData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilOrderData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilOrderData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilOrderData.class.getName());
+	private static final Logger logger = System.getLogger(UtilOrderData.class.getName());
 
 	@BeforeEach
 	public void setupOrderData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilPhoneData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilPhoneData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilPhoneData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilPhoneData.class.getName());
+	private static final Logger logger = System.getLogger(UtilPhoneData.class.getName());
 
 	@BeforeEach
 	public void setupPhoneData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilProductData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilProductData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilProductData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilProductData.class.getName());
+	private static final Logger logger = System.getLogger(UtilProductData.class.getName());
 
 	@BeforeEach
 	public void setupProductData() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilSetup.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilSetup.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilSetup extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilSetup.class.getName());
+	private static final Logger logger = System.getLogger(UtilSetup.class.getName());
 
 	@BeforeEach
 	public void setup() throws Exception {

--- a/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilTrimData.java
+++ b/tck/common/src/main/java/ee/jakarta/tck/persistence/common/schema30/UtilTrimData.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 
 public abstract class UtilTrimData extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(UtilTrimData.class.getName());
+	private static final Logger logger = System.getLogger(UtilTrimData.class.getName());
 
 	@BeforeEach
 	public void setupTrimData() throws Exception {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Employee3[] empRef = new Employee3[5];
 
@@ -67,17 +66,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupEmployeeData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
@@ -23,15 +23,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.StoredProcedureQuery;
 
-
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	List<Employee> empRef = new ArrayList<Employee>();
 
@@ -52,18 +49,6 @@ public class Client extends PMClientBase {
 	final static String POSTGRESQL = "postgresql";
 
 	public Client() {
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
     @Override

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
@@ -52,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Client1 extends Client {
 
-    private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+    private static final Logger logger = System.getLogger(Client1.class.getName());
 
     public Client1() {
     }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1.java
@@ -2459,11 +2459,11 @@ public class Client1 extends Client {
             final Date d5 = getUtilDate();
 
             emp0 = new Employee(1, "Alan", "Frechette", utilDate, (float) 35000.0);
-            empRef.add(emp0);
-            empRef.add(new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0));
-            empRef.add(new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0));
-            empRef.add(new Employee(4, "Robert", "Bissett", d4, (float) 55000.0));
-            empRef.add(new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
+            empRef = List.of(emp0,
+                    new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0),
+                    new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0),
+                    new Employee(4, "Robert", "Bissett", d4, (float) 55000.0),
+                    new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
             for (Employee e : empRef) {
                 if (e != null) {
                     getEntityManager().persist(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
@@ -497,11 +497,11 @@ public class Client2 extends Client {
 			final Calendar d5 = getCalDate();
 
 			emp2 = new Employee2(1, "Alan", "Frechette", calDate, (float) 35000.0);
-			empRef2.add(emp2);
-			empRef2.add(new Employee2(2, "Arthur", "Frechette", d2, (float) 35000.0));
-			empRef2.add(new Employee2(3, "Shelly", "McGowan", d3, (float) 50000.0));
-			empRef2.add(new Employee2(4, "Robert", "Bissett", d4, (float) 55000.0));
-			empRef2.add(new Employee2(5, "Stephen", "DMilla", d5, (float) 25000.0));
+			empRef2 = List.of(emp2,
+					new Employee2(2, "Arthur", "Frechette", d2, (float) 35000.0),
+					new Employee2(3, "Shelly", "McGowan", d3, (float) 50000.0),
+					new Employee2(4, "Robert", "Bissett", d4, (float) 55000.0),
+					new Employee2(5, "Stephen", "DMilla", d5, (float) 25000.0));
 			for (Employee2 e : empRef2) {
 				if (e != null) {
 					getEntityManager().persist(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
@@ -33,7 +33,7 @@ import jakarta.persistence.TemporalType;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public Client2() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client.java
@@ -18,8 +18,6 @@ package ee.jakarta.tck.persistence.core.annotations.access.field;
 
 import java.lang.System.Logger;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
@@ -33,17 +31,6 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client1.java
@@ -28,7 +28,7 @@ import jakarta.persistence.Query;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client2.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client3.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client3 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/field/Client4.java
@@ -27,7 +27,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client4 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static FullTimeEmployee ftRef[] = new FullTimeEmployee[5];
 
@@ -194,18 +193,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception rolling back TX:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client.java
@@ -18,8 +18,6 @@ package ee.jakarta.tck.persistence.core.annotations.access.property;
 
 import java.lang.System.Logger;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
@@ -30,18 +28,6 @@ public class Client extends PMClientBase {
 
 	final protected java.util.Date dateId = getPKDate(2006, 04, 15);
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-		logger.log(Logger.Level.TRACE, "cleanup");
-		removeTestData();
-		logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-		super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client1.java
@@ -27,7 +27,7 @@ import ee.jakarta.tck.persistence.core.types.common.Grade;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client2.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static PartTimeEmployee ptRef[] = new PartTimeEmployee[5];
 
@@ -157,15 +156,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/A.java
@@ -37,7 +37,7 @@ import jakarta.persistence.TemporalType;
 @Cacheable(value = true)
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client.java
@@ -24,13 +24,11 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -81,16 +79,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client1.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/A.java
@@ -38,7 +38,7 @@ public class A implements java.io.Serializable {
 
 	protected int value;
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@ElementCollection
 	@CollectionTable(name = "COLTAB_ADDRESS", joinColumns = @JoinColumn(name = "A_ID"))

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/collectiontable/Client.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -158,19 +157,6 @@ public class Client extends PMClientBase {
 				logger.log(Logger.Level.TRACE, "  address=numm");
 			}
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/convert/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/convert/Client.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -732,15 +731,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/Client.java
@@ -19,15 +19,16 @@ package ee.jakarta.tck.persistence.core.annotations.discriminatorValue;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -133,15 +134,16 @@ public class Client extends PMClientBase {
 	public void discriminatorValueTest() throws Exception {
 		boolean pass1 = false;
 		final String testName = "discriminatorValueTest";
+		final String otherTestName = "otherDiscriminatorValueTest";
 		try {
 			getEntityTransaction().begin();
 			PartProduct p1 = newPartProduct(testName);
 			getEntityManager().persist(p1);
 			getEntityManager().flush();
 			clearCache();
-			PartProduct p2 = getEntityManager().find(PartProduct.class, testName);
+			Product p2 = getEntityManager().find(Product.class, testName);
 			logger.log(Logger.Level.TRACE, "finding PartProduct with id '" + testName + "'");
-
+            assertInstanceOf(PartProduct.class, p2);
 			if (p1.equals(p2)) {
 				logger.log(Logger.Level.TRACE, "Received expected PartProduct:" + p2);
 				pass1 = true;
@@ -151,12 +153,12 @@ public class Client extends PMClientBase {
 				logger.log(Logger.Level.ERROR, "Actual:" + p2);
 			}
 
-			Product p3 = newProduct(testName);
+			Product p3 = newProduct(otherTestName);
 			getEntityManager().persist(p3);
 			getEntityManager().flush();
 			clearCache();
-			Product p4 = getEntityManager().find(Product.class, testName);
-			logger.log(Logger.Level.TRACE, "finding Product with id '" + testName + "'");
+			Product p4 = getEntityManager().find(Product.class, otherTestName);
+			logger.log(Logger.Level.TRACE, "finding Product with id '" + otherTestName + "'");
 
 			if (p3.equals(p4)) {
 				logger.log(Logger.Level.TRACE, "Received expected Product:" + p2);
@@ -177,15 +179,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/A.java
@@ -38,7 +38,7 @@ public class A implements java.io.Serializable {
 
 	protected int value;
 
-	private static final Logger logger = (Logger) System.getLogger(LogFileProcessor.class.getName());
+	private static final Logger logger = System.getLogger(LogFileProcessor.class.getName());
 
 	@ElementCollection(fetch = FetchType.EAGER, targetClass = Address.class)
 	// @CollectionTable(name="A_ADDRESS2")

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ public class Client1 extends PMClientBase {
 	public Client1() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();
@@ -51,7 +50,7 @@ public class Client1 extends PMClientBase {
 		try {
 			super.setup();
 			createDeployment();
-			removeATestData();
+			removeTestData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
@@ -154,41 +153,6 @@ public class Client1 extends PMClientBase {
 			}
 		} else {
 			logger.log(Logger.Level.TRACE, "  address=NULL");
-		}
-	}
-
-	@AfterEach
-	public void cleanupA() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeATestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeATestData() {
-		logger.log(Logger.Level.TRACE, "removeATestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from A_ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from AEC").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ public class Client2 extends PMClientBase {
 	public Client2() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();
@@ -52,7 +51,7 @@ public class Client2 extends PMClientBase {
 		try {
 			super.setup();
 			createDeployment();
-			removeCustTestData();
+			removeTestData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
@@ -187,40 +186,5 @@ public class Client2 extends PMClientBase {
 	 * Business Methods to set up data for Test Cases
 	 *
 	 */
-
-	@AfterEach
-	public void cleanupCust() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeCustTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeCustTestData() {
-		logger.log(Logger.Level.TRACE, "removeCustTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.annotations.embeddable;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -163,15 +162,4 @@ public class Client extends PMClientBase {
 		return getEntityManager().find(B.class, id);
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/Client.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -163,15 +162,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -245,15 +244,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/Client.java
@@ -22,7 +22,6 @@ import java.math.BigInteger;
 import java.math.RoundingMode;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -720,15 +719,4 @@ public class Client extends PMClientBase {
 			throw new Exception("PropertyUtilDateIdTest failed");
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/FieldBigDecimalId.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/FieldBigDecimalId.java
@@ -28,7 +28,7 @@ import jakarta.persistence.Table;
 @Table(name = "DATATYPES3")
 public class FieldBigDecimalId implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(FieldBigDecimalId.class.getName());
+	private static final Logger logger = System.getLogger(FieldBigDecimalId.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Arrays;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private DataTypes dataTypes;
 
@@ -197,15 +196,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client.java
@@ -24,8 +24,6 @@ import java.lang.System.Logger;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
@@ -33,7 +31,7 @@ public class Client extends PMClientBase {
 	public Client() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	protected Employee empRef[] = new Employee[10];
 
@@ -134,15 +132,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1.java
@@ -34,7 +34,7 @@ public class Client1 extends Client {
 	public Client1() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2.java
@@ -31,7 +31,7 @@ public class Client2 extends Client {
 	public Client2() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/Client.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class Client extends PMClientBase {
 
 	private Map<Course, Semester> student2EnrollmentMap;
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -168,15 +167,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
@@ -505,6 +505,7 @@ public class Client extends PMClientBase {
 			empRef[4] = new Employee(5, "Stephen", "DMilla");
 			empRef[4].setDepartment(deptRef[0]);
 
+			link = new HashMap<String, Employee>();
 			link.put("OFF-000", empRef[0]);
 			link.put("OFF-002", empRef[2]);
 			link.put("OFF-004", empRef[4]);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/Client.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -567,18 +566,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception in rollback:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/Client.java
@@ -26,7 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 20L;
 
@@ -608,18 +607,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception in rollback:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/Client.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ public class Client extends PMClientBase {
 
 	private Map<Course, Semester> student7EnrollmentMap;
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -263,15 +262,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/Client.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +37,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
@@ -483,38 +482,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanupCust() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeCustTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeCustTestData() {
-		logger.log(Logger.Level.TRACE, "removeCustTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM DATES_TABLE").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -138,15 +137,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/Client.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.TransactionRequiredException;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -935,18 +934,6 @@ public class Client extends PMClientBase {
 
 		if (!pass)
 			throw new Exception("getSingleResultTest failed");
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.annotations.onexmanyuni;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	final private static long ORDER1_ID = 786l;
 
@@ -146,15 +145,4 @@ public class Client extends PMClientBase {
 		return customer;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	List<Address> addrRef;
 
@@ -440,18 +439,6 @@ public class Client1 extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception in rollback:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	List<Address> addrRef;
 
@@ -66,7 +65,7 @@ public class Client2 extends PMClientBase {
 			super.setup();
 			createDeployment();
 
-			removeAddressData();
+			removeTestData();
 			createAddressData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
@@ -252,38 +251,4 @@ public class Client2 extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanupAddress() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeAddressData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeAddressData() {
-		logger.log(Logger.Level.TRACE, "removeAddressData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from COLTAB_ADDRESS").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from COLTAB").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client3 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	List<Address> addrRef;
 
@@ -66,7 +65,7 @@ public class Client3 extends PMClientBase {
 			super.setup();
 			createDeployment();
 
-			removeCustTestData();
+			removeTestData();
 		} catch (Exception e) {
 			e.printStackTrace();
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
@@ -191,41 +190,6 @@ public class Client3 extends PMClientBase {
 		}
 		if (!pass) {
 			throw new Exception("fieldElementCollectionBasicType failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanupCust() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeCustTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeCustTestData() {
-		logger.log(Logger.Level.TRACE, "removeCustTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.Query;
 public class Client1 extends PMClientBase {
 
 	private List<Student> expectedResults;
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public Client1() {
 	}
@@ -252,18 +251,6 @@ public class Client1 extends PMClientBase {
 			}
 		}
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ public class Client2 extends PMClientBase {
 
 	private List<Employee2> expectedEmployees2;
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public Client2() {
 	}
@@ -57,7 +56,7 @@ public class Client2 extends PMClientBase {
 
 			super.setup();
 			createDeployment();
-			removeEmployeeTestData();
+			removeTestData();
 			createEmployeeTestData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
@@ -425,38 +424,4 @@ public class Client2 extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanupEmployee() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanupEmployee");
-			removeEmployeeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeEmployeeTestData() {
-		logger.log(Logger.Level.TRACE, "removeEmployeeTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("Delete from EMPLOYEE").executeUpdate();
-			getEntityManager().createNativeQuery("Delete from DEPARTMENT").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client.java
@@ -18,27 +18,13 @@ package ee.jakarta.tck.persistence.core.annotations.tableGenerator;
 
 import java.lang.System.Logger;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1.java
@@ -26,7 +26,7 @@ public class Client1 extends Client {
 
 	private DataTypes d0;
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public Client1() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2.java
@@ -26,7 +26,7 @@ public class Client2 extends Client {
 
 	private DataTypes2 d2;
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public Client2() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3.java
@@ -29,7 +29,7 @@ public class Client3 extends Client {
 	public Client3() {
 	}
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4.java
@@ -26,7 +26,7 @@ public class Client4 extends Client {
 
 	private DataTypes4 d4;
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public Client4() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/Client.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 21L;
 	Date date = null;
@@ -295,18 +294,6 @@ public class Client extends PMClientBase {
 			throw new Exception("idPropertyTest failed");
 		}
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 	public void createTestData() {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client.java
@@ -18,26 +18,13 @@ package ee.jakarta.tck.persistence.core.annotations.version;
 
 import java.lang.System.Logger;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public Client1() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public Client2() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client3 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public Client3() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client4 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public Client4() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.basic;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -149,15 +148,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.cache.basicTests;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -367,16 +366,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/added/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/added/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.callback.added;
 import java.lang.System.Logger;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -325,15 +324,4 @@ public class Client extends EntityCallbackClientBase {
 		return product;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/EntityCallbackClientBase.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/EntityCallbackClientBase.java
@@ -27,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public abstract class EntityCallbackClientBase extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(EntityCallbackClientBase.class.getName());
+	private static final Logger logger = System.getLogger(EntityCallbackClientBase.class.getName());
 
 	protected EntityCallbackClientBase() {
 		super();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/GenerictListenerImpl.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/GenerictListenerImpl.java
@@ -29,7 +29,7 @@ import java.lang.System.Logger;
  */
 public class GenerictListenerImpl {
 
-	private static final Logger logger = (Logger) System.getLogger(GenerictListenerImpl.class.getName());
+	private static final Logger logger = System.getLogger(GenerictListenerImpl.class.getName());
 
 	public GenerictListenerImpl() {
 		super();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/ListenerBase.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/common/ListenerBase.java
@@ -29,7 +29,7 @@ import java.lang.System.Logger;
  */
 abstract public class ListenerBase {
 
-	private static final Logger logger = (Logger) System.getLogger(ListenerBase.class.getName());
+	private static final Logger logger = System.getLogger(ListenerBase.class.getName());
 
 	protected ListenerBase() {
 		super();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.callback.inheritance;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ public class Client extends EntityCallbackClientBase {
 
 	private PricedPartProduct_2 p2;
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 		super();
@@ -465,15 +464,4 @@ public class Client extends EntityCallbackClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ProductListener.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ProductListener.java
@@ -37,7 +37,7 @@ import jakarta.persistence.PreUpdate;
  */
 public class ProductListener {
 
-	private static final Logger logger = (Logger) System.getLogger(ProductListener.class.getName());
+	private static final Logger logger = System.getLogger(ProductListener.class.getName());
 
 	public ProductListener() {
 		super();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -566,15 +565,4 @@ public class Client extends EntityCallbackClientBase {
 		return lineItem;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -558,15 +557,4 @@ public class Client extends EntityCallbackClientBase {
 		return lineItem;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/Client.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -572,15 +571,4 @@ public class Client extends EntityCallbackClientBase {
 		return lineItem;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/Client.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private Product product;
 
@@ -566,15 +565,4 @@ public class Client extends EntityCallbackClientBase {
 		return lineItem;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ import jakarta.persistence.Query;
 
 public class Client extends EntityCallbackClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -672,15 +671,4 @@ public class Client extends EntityCallbackClientBase {
 		return customer;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/Client.java
@@ -33,6 +33,9 @@ import ee.jakarta.tck.persistence.core.callback.common.Constants;
 import ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase;
 import jakarta.persistence.Query;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class Client extends EntityCallbackClientBase {
 
 	private static final Logger logger = System.getLogger(Client.class.getName());
@@ -584,10 +587,9 @@ public class Client extends EntityCallbackClientBase {
 			product = newProduct(testName);
 			product = (Product) txShouldRollback(product, testName);
 			List actual = product.getPrePersistCalls();
-			List expected = new ArrayList(Arrays.asList("ListenerA"));
-			if (!product.isPrePersistCalled() || !expected.equals(actual)) {
-				logger.log(Logger.Level.ERROR, "Expected: " + expected.toString() + ", actual:" + actual.toString());
-			}
+			List<String> expected = List.of(Constants.LISTENER_AA);
+			assertTrue(product.isPrePersistCalled());
+			assertEquals(actual, expected);
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception caught during prePersistRuntimeExceptionTest", e);
 			throw new Exception(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1.java
@@ -37,7 +37,7 @@ import jakarta.persistence.criteria.Selection;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2.java
@@ -50,7 +50,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client2 extends UtilCustAliasProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3.java
@@ -46,7 +46,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client3 extends UtilAliasData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4.java
@@ -36,7 +36,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client4 extends UtilAliasOnlyData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5.java
@@ -49,7 +49,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client5 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client5.class.getName());
+	private static final Logger logger = System.getLogger(Client5.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6.java
@@ -46,7 +46,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client6 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client6.class.getName());
+	private static final Logger logger = System.getLogger(Client6.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7.java
@@ -36,7 +36,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client7 extends UtilCustAliasProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client7.class.getName());
+	private static final Logger logger = System.getLogger(Client7.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8.java
@@ -34,7 +34,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client8 extends UtilTrimData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client8.class.getName());
+	private static final Logger logger = System.getLogger(Client8.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/Client.java
@@ -39,7 +39,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/A.java
@@ -111,7 +111,7 @@ public class A implements java.io.Serializable {
 	@Basic
 	protected Timestamp basicTimestamp;
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// constructors

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1.java
@@ -48,7 +48,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client1 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2.java
@@ -36,7 +36,7 @@ import jakarta.persistence.criteria.Selection;
 
 public class Client2 extends UtilAliasData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3.java
@@ -55,7 +55,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client3 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4.java
@@ -32,7 +32,7 @@ import jakarta.persistence.metamodel.Bindable;
 
 public class Client4 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5.java
@@ -39,7 +39,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client5 extends Util {
 
-	private static final Logger logger = (Logger) System.getLogger(Client5.class.getName());
+	private static final Logger logger = System.getLogger(Client5.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6.java
@@ -36,7 +36,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client6 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client6.class.getName());
+	private static final Logger logger = System.getLogger(Client6.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7.java
@@ -36,7 +36,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client7 extends UtilDepartmentEmployeeData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client7.class.getName());
+	private static final Logger logger = System.getLogger(Client7.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/Client.java
@@ -38,7 +38,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1.java
@@ -31,7 +31,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2.java
@@ -40,7 +40,7 @@ import jakarta.persistence.criteria.Subquery;
 
 public class Client2 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3.java
@@ -39,7 +39,7 @@ import jakarta.persistence.criteria.SetJoin;
 
 public class Client3 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4.java
@@ -41,7 +41,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client4 extends UtilDepartmentEmployeeData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1.java
@@ -36,7 +36,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2.java
@@ -50,7 +50,7 @@ import jakarta.persistence.metamodel.PluralAttribute;
 
 public class Client2 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3.java
@@ -42,7 +42,7 @@ import jakarta.persistence.metamodel.PluralAttribute;
 
 public class Client3 extends UtilDepartmentEmployeeData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1.java
@@ -30,7 +30,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2.java
@@ -38,7 +38,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client2 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3.java
@@ -39,7 +39,7 @@ import jakarta.persistence.criteria.SetJoin;
 
 public class Client3 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4.java
@@ -37,7 +37,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client4 extends UtilDepartmentEmployeeData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1.java
@@ -50,7 +50,7 @@ import jakarta.persistence.metamodel.Attribute;
 
 public class Client1 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2.java
@@ -61,7 +61,7 @@ import jakarta.persistence.metamodel.SetAttribute;
 
 public class Client2 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3.java
@@ -43,7 +43,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client3 extends UtilAliasData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4.java
@@ -38,7 +38,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client4 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5.java
@@ -35,7 +35,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client5 extends UtilAliasOnlyData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client5.class.getName());
+	private static final Logger logger = System.getLogger(Client5.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client5.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6.java
@@ -40,7 +40,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client6 extends UtilPhoneData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client6.class.getName());
+	private static final Logger logger = System.getLogger(Client6.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client6.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7.java
@@ -68,7 +68,7 @@ public class Client7 extends UtilSetup {
 			Set cJoins = sq.getCorrelatedJoins();
 			if (cJoins != null) {
 				if (cJoins.size() == 0) {
-					logger.log(Logger.Level.ERROR,
+					logger.log(Logger.Level.TRACE,
 							"Received expected 0 correlated joins from subquery.getCorrelatedJoins() when none exist");
 
 					// correlate subquery

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7.java
@@ -37,7 +37,7 @@ import jakarta.persistence.criteria.Subquery;
 
 public class Client7 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client7.class.getName());
+	private static final Logger logger = System.getLogger(Client7.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client7.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1.java
@@ -38,7 +38,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2.java
@@ -42,7 +42,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client2 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3.java
@@ -45,7 +45,7 @@ import jakarta.persistence.metamodel.EntityType;
 
 public class Client3 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client.java
@@ -19,31 +19,18 @@ package ee.jakarta.tck.persistence.core.criteriaapi.parameter;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public abstract class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Employee[] empRef = new Employee[5];
 
 	final java.sql.Date d1 = getSQLDate("2000-02-14");
 
-
 	abstract public JavaArchive createDeployment() throws Exception;
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "calling super.cleanup");
-			removeTestData();
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 
 	protected void createTestData() {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1.java
@@ -34,7 +34,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2.java
@@ -38,7 +38,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1.java
@@ -32,7 +32,7 @@ import jakarta.persistence.metamodel.Attribute;
 
 public class Client1 extends UtilSetup {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2.java
@@ -42,7 +42,7 @@ import jakarta.persistence.criteria.Subquery;
 
 public class Client2 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3.java
@@ -43,7 +43,7 @@ import jakarta.persistence.criteria.Subquery;
 
 public class Client3 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4.java
@@ -34,7 +34,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client4 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5.java
@@ -40,7 +40,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client5 extends UtilAliasData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client5.class.getName());
+	private static final Logger logger = System.getLogger(Client5.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -128,15 +127,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -125,15 +124,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -128,15 +127,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -142,15 +141,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -128,15 +127,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -153,18 +152,6 @@ public class Client extends PMClientBase {
 
 		if (!pass) {
 			throw new Exception("DIDTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -117,15 +116,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -119,15 +118,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -120,15 +119,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -140,15 +139,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -121,15 +120,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -140,15 +139,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	List<Employee> empRef = new ArrayList<Employee>();
 
@@ -92,16 +91,6 @@ public class Client1 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
@@ -497,11 +497,11 @@ public class Client2 extends PMClientBase {
 			final Date d5 = getUtilDate();
 
 			emp0 = new Employee(1, "Alan", "Frechette", d1, (float) 35000.0);
-			empRef.add(emp0);
-			empRef.add(new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0));
-			empRef.add(new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0));
-			empRef.add(new Employee(4, "Robert", "Bissett", d4, (float) 55000.0));
-			empRef.add(new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
+			empRef = List.of(emp0,
+					new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0),
+					new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0),
+					new Employee(4, "Robert", "Bissett", d4, (float) 55000.0),
+					new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
 			for (Employee e : empRef) {
 				if (e != null) {
 					getEntityManager().persist(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ import jakarta.persistence.StoredProcedureQuery;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	List<Employee> empRef = new ArrayList<Employee>();
 
@@ -91,16 +90,6 @@ public class Client2 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.StoredProcedureQuery;
 
 public class Client3 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	List<Employee> empRef = new ArrayList<Employee>();
 
@@ -85,17 +84,6 @@ public class Client3 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3.java
@@ -417,11 +417,11 @@ public class Client3 extends PMClientBase {
 			final Date d5 = getUtilDate();
 
 			emp0 = new Employee(1, "Alan", "Frechette", d1, (float) 35000.0);
-			empRef.add(emp0);
-			empRef.add(new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0));
-			empRef.add(new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0));
-			empRef.add(new Employee(4, "Robert", "Bissett", d4, (float) 55000.0));
-			empRef.add(new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
+			empRef = List.of(emp0,
+					new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0),
+					new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0),
+					new Employee(4, "Robert", "Bissett", d4, (float) 55000.0),
+					new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
 			for (Employee e : empRef) {
 				if (e != null) {
 					getEntityManager().persist(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Order.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Order.java
@@ -69,16 +69,16 @@ public class Order implements java.io.Serializable {
 		this.total = total;
 	}
 
-	public String getdescription() {
+	public String getDescription() {
 		return description;
 	}
 
-	public void setdescription(String description) {
+	public void setDescription(String description) {
 		this.description = description;
 	}
 
 	public String toString() {
-		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getdescription();
+		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getDescription();
 	}
 
 	@Override
@@ -93,7 +93,7 @@ public class Order implements java.io.Serializable {
 
 		boolean result = false;
 
-		if (this.getId() == o1.getId() && this.getdescription().equals(o1.getdescription())
+		if (this.getId() == o1.getId() && this.getDescription().equals(o1.getDescription())
 				&& this.getTotal() == o1.getTotal()) {
 			result = true;
 		}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Statement;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	Map<String, Object> map = new HashMap<>();
 
@@ -80,17 +79,6 @@ public class Client1 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-            getEntityManagerFactory().getSchemaManager().truncate();
-            super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.entityManager2;
 import java.lang.System.Logger;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.BeforeEach;
@@ -140,7 +139,7 @@ public class Client2 extends PMClientBase {
 			getEntityTransaction().begin();
 			Order o = getEntityManager().find(Order.class, 4);
 			getEntityTransaction().commit();
-			o.setdescription("FOOBAR");
+			o.setDescription("FOOBAR");
 			getEntityManager().refresh(o, LockModeType.PESSIMISTIC_READ);
 			logger.log(Logger.Level.ERROR, "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {
@@ -164,7 +163,7 @@ public class Client2 extends PMClientBase {
 			getEntityTransaction().begin();
 			Order o = getEntityManager().find(Order.class, 4);
 			getEntityTransaction().commit();
-			o.setdescription("FOOBAR");
+			o.setDescription("FOOBAR");
 			getEntityManager().refresh(o, LockModeType.PESSIMISTIC_READ, myMap);
 			logger.log(Logger.Level.ERROR, "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.TransactionRequiredException;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	Order[] orders = new Order[5];
 
@@ -76,17 +75,6 @@ public class Client2 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -26,7 +26,6 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.RefreshOption;
 import jakarta.persistence.Timeout;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -86,17 +85,6 @@ public class Client3 extends PMClientBase {
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception: ", e);
             throw new Exception("Setup failed:", e);
-        }
-    }
-
-    @AfterEach
-    public void cleanupData() throws Exception {
-        try {
-            logger.log(Logger.Level.TRACE, "Cleanup data");
-            removeTestData();
-            cleanup();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 
@@ -317,8 +305,6 @@ public class Client3 extends PMClientBase {
             throw new Exception("setCacheStoreModeTest failed");
         }
     }
-
-
     private void createOrderData() {
 
         try {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -97,7 +97,7 @@ public class Client3 extends PMClientBase {
             Order order = new Order(1, 111, "desc1");
             Order reference = getEntityManager().getReference(order);
             // Verify that access to entity attribute works
-            String orderDescription = reference.getdescription();
+            String orderDescription = reference.getDescription();
             getEntityTransaction().commit();
 
             if (reference instanceof Order) {
@@ -135,7 +135,7 @@ public class Client3 extends PMClientBase {
             // Verify that getReference() to order fails
             // EntityNotFoundException shall be thrown on non-existing entity access
             Order referenceOrder = getEntityManager().getReference(order);
-            String description = referenceOrder.getdescription();
+            String description = referenceOrder.getDescription();
         } catch (EntityNotFoundException enfe) {
             pass = true;
         } catch (Exception e) {
@@ -158,7 +158,7 @@ public class Client3 extends PMClientBase {
                                 "INSERT INTO PURCHASE_ORDER(ID, TOTAL, DESCRIPTION) VALUES(?, ?, ?)")) {
                             stmt.setInt(1, newOrder.getId());
                             stmt.setInt(2, newOrder.getTotal());
-                            stmt.setString(3, newOrder.getdescription());
+                            stmt.setString(3, newOrder.getDescription());
                             stmt.executeUpdate();
                         }
                     }
@@ -198,7 +198,7 @@ public class Client3 extends PMClientBase {
                                 "INSERT INTO PURCHASE_ORDER(ID, TOTAL, DESCRIPTION) VALUES(?, ?, ?)")) {
                             stmt.setInt(1, newOrder.getId());
                             stmt.setInt(2, newOrder.getTotal());
-                            stmt.setString(3, newOrder.getdescription());
+                            stmt.setString(3, newOrder.getDescription());
                             stmt.executeUpdate();
                         }
                         Order order = new Order();
@@ -210,7 +210,7 @@ public class Client3 extends PMClientBase {
                             rSet.next();
                             order.setId(rSet.getInt(1));
                             order.setTotal(rSet.getInt(2));
-                            order.setdescription(rSet.getString(3));
+                            order.setDescription(rSet.getString(3));
                             rSet.close();
                         }
                         return order;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Order.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Order.java
@@ -71,16 +71,16 @@ public class Order implements java.io.Serializable {
 		this.total = total;
 	}
 
-	public String getdescription() {
+	public String getDescription() {
 		return description;
 	}
 
-	public void setdescription(String description) {
+	public void setDescription(String description) {
 		this.description = description;
 	}
 
 	public String toString() {
-		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getdescription();
+		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getDescription();
 	}
 
 	@Override

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	Properties props = null;
 
@@ -63,17 +62,6 @@ public class Client1 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "done cleanup, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	Properties props = null;
 
@@ -59,15 +58,6 @@ public class Client2 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupNoData() throws Exception {
-		try {
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client3 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	Properties props = null;
 
@@ -62,15 +61,6 @@ public class Client3 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupNoData() throws Exception {
-		try {
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client4.java
@@ -18,7 +18,6 @@ package ee.jakarta.tck.persistence.core.entityManagerFactory;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,15 +48,6 @@ public class Client4 extends PMClientBase {
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception: ", e);
             throw new Exception("Setup failed:", e);
-        }
-    }
-
-    @AfterEach
-    public void cleanupNoData() throws Exception {
-        try {
-            super.cleanup();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/Client.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Properties props = null;
 
@@ -58,15 +57,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityTransaction/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityTransaction/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Properties props = null;
 
@@ -55,17 +54,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		// Nothing to cleanup
-		try {
-			logger.log(Logger.Level.TRACE, "done cleanup, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static Coffee cRef[] = new Coffee[5];
 
@@ -973,15 +972,4 @@ public class Client extends PMClientBase {
 		return passCounter;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/A.java
@@ -35,7 +35,7 @@ import jakarta.persistence.TemporalType;
 @Table(name = "A_BIGDECIMAL")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/Client.java
@@ -25,7 +25,6 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -533,15 +532,4 @@ public class Client extends PMClientBase {
 		return getEntityManager().contains(o);
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/A.java
@@ -35,7 +35,7 @@ import jakarta.persistence.TemporalType;
 @Table(name = "A_BIGINTEGER")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/Client.java
@@ -25,7 +25,6 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -532,15 +531,4 @@ public class Client extends PMClientBase {
 		return getEntityManager().contains(o);
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/A.java
@@ -37,7 +37,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MXM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/B.java
@@ -35,7 +35,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MXM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/Client.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -767,15 +766,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MX1_UNI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MX1_UNI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -625,18 +624,6 @@ public class Client extends PMClientBase {
 	private boolean getInstanceStatus(final Object o) {
 		logger.log(Logger.Level.TRACE, "Entered getInstanceStatus method");
 		return getEntityManager().contains(o);
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/B.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -759,15 +758,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1X1_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1X1_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/Client.java
@@ -22,7 +22,6 @@ package ee.jakarta.tck.persistence.core.entitytest.cascadeall.oneXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -686,15 +685,4 @@ public class Client extends PMClientBase {
 		return getEntityManager().contains(o);
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/basic/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.detach.basic;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -205,18 +204,6 @@ public class Client extends PMClientBase {
 		getEntityTransaction().begin();
 		getEntityManager().persist(a);
 		getEntityTransaction().commit();
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MXM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MXM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXmany/Client.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Iterator;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -178,19 +177,6 @@ public class Client extends PMClientBase {
 		getEntityTransaction().begin();
 		getEntityManager().persist(a);
 		getEntityTransaction().commit();
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MX1_UNI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MX1_UNI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/manyXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.detach.manyXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.EntityExistsException;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -151,15 +150,4 @@ public class Client extends PMClientBase {
 		getEntityTransaction().commit();
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/B.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXmany/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.EntityExistsException;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -240,18 +239,6 @@ public class Client extends PMClientBase {
 			logger.log(Logger.Level.TRACE, "- Element #" + elem++);
 			logger.log(Logger.Level.TRACE,
 					"  id=" + v.getBId() + ", name=" + v.getBName() + ", value=" + v.getBValue());
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1X1_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1X1_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/detach/oneXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.detach.oneXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.EntityExistsException;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -217,18 +216,6 @@ public class Client extends PMClientBase {
 		getEntityTransaction().begin();
 		getEntityManager().persist(b);
 		getEntityTransaction().commit();
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.persist.basic;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -385,18 +384,6 @@ public class Client extends PMClientBase {
 	private boolean getInstanceStatus(final Object o) {
 		logger.log(Logger.Level.TRACE, "Entered getInstanceStatus method");
 		return getEntityManager().contains(o);
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MXM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MXM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/Client.java
@@ -25,7 +25,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -789,18 +788,6 @@ public class Client extends PMClientBase {
 			logger.log(Logger.Level.TRACE, "- Element #" + elem++);
 			logger.log(Logger.Level.TRACE,
 					"  id=" + v.getBId() + ", name=" + v.getBName() + ", value=" + v.getBValue());
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_MX1_UNI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_MX1_UNI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.persist.manyXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -659,18 +658,6 @@ public class Client extends PMClientBase {
 	private boolean getInstanceStatus(final Object o) {
 		logger.log(Logger.Level.TRACE, "Entered getInstanceStatus method");
 		return getEntityManager().contains(o);
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/B.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -948,15 +947,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1X1_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/B.java
@@ -35,7 +35,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1X1_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.persist.oneXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -749,15 +748,4 @@ public class Client extends PMClientBase {
 		return getEntityManager().contains(o);
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.remove.basic;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -387,18 +386,6 @@ public class Client extends PMClientBase {
 	private A findA(final String id) {
 		logger.log(Logger.Level.TRACE, "Entered findA method");
 		return getEntityManager().find(A.class, id);
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/A.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/B.java
@@ -33,7 +33,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -621,18 +620,6 @@ public class Client extends PMClientBase {
 			logger.log(Logger.Level.TRACE, "- Element #" + elem++);
 			logger.log(Logger.Level.TRACE,
 					"  id=" + v.getBId() + ", name=" + v.getBName() + ", value=" + v.getBValue());
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1X1_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/B.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1X1_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.entitytest.remove.oneXone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -607,18 +606,6 @@ public class Client extends PMClientBase {
 	private boolean getInstanceStatus(final Object o) {
 		logger.log(Logger.Level.TRACE, "Entered getInstanceStatus method");
 		return getEntityManager().contains(o);
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/Client.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +65,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -252,20 +251,6 @@ public class Client extends PMClientBase {
 
 		if (!pass)
 			throw new Exception("setgetFlushModeTQTest failed");
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			if (getEntityManager().isOpen()) {
-				removeTestData();
-			}
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/exceptions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/exceptions/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.exceptions;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import jakarta.persistence.TransactionRequiredException;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -1715,17 +1714,4 @@ public class Client extends PMClientBase {
 			throw new Exception("NoResultExceptionTest failed");
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			if (getEntityManager().isOpen()) {
-				removeTestData();
-			}
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final FullTimeEmployee ftRef[] = new FullTimeEmployee[5];
 
@@ -280,15 +279,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final FullTimeEmployee ftRef[] = new FullTimeEmployee[5];
 
@@ -199,18 +198,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception rolling back TX:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final FullTimeEmployee ftRef[] = new FullTimeEmployee[5];
 
@@ -199,18 +198,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception rolling back TX:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final FullTimeEmployee ftRef[] = new FullTimeEmployee[5];
 
@@ -269,15 +268,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/FTEmployee.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/FTEmployee.java
@@ -29,7 +29,7 @@ import java.sql.Date;
 
 public class FTEmployee extends Employee {
 
-	private static final Logger logger = (Logger) System.getLogger(FTEmployee.class.getName());
+	private static final Logger logger = System.getLogger(FTEmployee.class.getName());
 
 	private float salary;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/FullTimeEmployee.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/FullTimeEmployee.java
@@ -35,7 +35,7 @@ import jakarta.persistence.Entity;
 @DiscriminatorValue("EXEMPT")
 public class FullTimeEmployee extends Employee {
 
-	private static final Logger logger = (Logger) System.getLogger(FullTimeEmployee.class.getName());
+	private static final Logger logger = System.getLogger(FullTimeEmployee.class.getName());
 
 	private float salary;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/PartTimeEmployee.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/PartTimeEmployee.java
@@ -35,7 +35,7 @@ import jakarta.persistence.Entity;
 @DiscriminatorValue("NONEXEMPT")
 public class PartTimeEmployee extends Employee {
 
-	private static final Logger logger = (Logger) System.getLogger(PartTimeEmployee.class.getName());
+	private static final Logger logger = System.getLogger(PartTimeEmployee.class.getName());
 
 	private float wage;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Project.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/Project.java
@@ -34,7 +34,7 @@ import jakarta.persistence.OneToOne;
 @Entity
 public class Project implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(Project.class.getName());
+	private static final Logger logger = System.getLogger(Project.class.getName());
 
 	// Instance Variables
 	private long projId;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/entitymanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/entitymanager/Client.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import jakarta.persistence.LockOption;
 import jakarta.persistence.Timeout;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.LockModeType;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -638,15 +637,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/query/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/lock/query/Client.java
@@ -21,7 +21,6 @@ import java.sql.Date;
 import java.util.Collection;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private final Date d1 = getSQLDate("2000-02-14");
 
@@ -766,15 +765,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.attribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -353,15 +352,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.basictype;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -149,15 +148,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Version;
 @Table(name = "COLTAB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@Id
 	protected String id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -139,15 +138,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.collectionattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.metamodel.PluralAttribute;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -147,21 +146,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "in cleanup");
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception fe) {
-				logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
-			}
-			logger.log(Logger.Level.TRACE, "done cleanup, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/Client.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ import jakarta.persistence.metamodel.SingularAttribute;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -2519,15 +2518,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/A.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Version;
 @AttributeOverrides({ @AttributeOverride(name = "name", column = @Column(name = "NAME")) })
 public class A extends B {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@Id
 	protected String id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/Client.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +35,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -801,15 +800,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/A.java
@@ -41,7 +41,7 @@ import jakarta.persistence.Version;
 @AttributeOverrides({ @AttributeOverride(name = "name", column = @Column(name = "NAME")) })
 public class A extends B {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@Id
 	protected String id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/B.java
@@ -33,7 +33,7 @@ import jakarta.persistence.MappedSuperclass;
 @MappedSuperclass()
 public abstract class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	protected String name;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -3062,15 +3061,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.listattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -282,15 +281,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "COLTAB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@Id
 	protected String id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/Client.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +39,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -2841,15 +2840,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.mapattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -246,15 +245,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/Client.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import jakarta.persistence.metamodel.SingularAttribute;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -758,15 +757,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/B.java
@@ -28,7 +28,7 @@ import jakarta.persistence.Table;
 @Table(name = "B_EMBEDDABLE")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/Client.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.metamodel.Metamodel;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -491,15 +490,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.pluralattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -524,15 +523,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/A.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "COLTAB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	@Id
 	protected String id;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.setattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -178,15 +177,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.singularattribute;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -619,15 +618,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.metamodelapi.type;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.metamodel.Type;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -166,15 +165,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "ANE_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/B.java
@@ -33,7 +33,7 @@ import jakarta.persistence.Table;
 @Table(name = "BNE_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -434,15 +433,4 @@ public class Client extends PMClientBase {
 		return resultB;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final int ENTITY_ID = 3039;
 
@@ -102,15 +101,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.override.callbacklistener;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.core.override.util.CallBackCounts;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -228,15 +227,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.override.embeddable;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Integer BOOKSTORE_ID = 12345;
 
@@ -272,15 +271,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private final static Long ID = 9l;
 
@@ -211,15 +210,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.override.entitylistener;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.core.override.util.CallBackCounts;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Long ID = 1L;
 
@@ -220,15 +219,4 @@ public class Client extends PMClientBase {
 		return result;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ListenerC.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ListenerC.java
@@ -24,7 +24,7 @@ import jakarta.persistence.PrePersist;
 
 public class ListenerC {
 
-	private static final Logger logger = (Logger) System.getLogger(ListenerC.class.getName());
+	private static final Logger logger = System.getLogger(ListenerC.class.getName());
 
 	public ListenerC() {
 	}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/Client.java
@@ -22,14 +22,13 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long COMPANY_ID = 676l;
 
@@ -393,15 +392,4 @@ public class Client extends PMClientBase {
 		return customer;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/Client.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Integer COURSE1_ID = 203;
 
@@ -147,15 +146,4 @@ public class Client extends PMClientBase {
 		return course;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/Client.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Query;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long DEPT1_ID = 777l;
 
@@ -416,15 +415,4 @@ public class Client extends PMClientBase {
 		return order;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.core.override.util.CallBackCounts;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Long ID = 1L;
 
@@ -173,15 +172,4 @@ public class Client extends PMClientBase {
 		return pass;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.override.table;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Long ID = 1L;
 
@@ -79,18 +78,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "test failed");
 			throw new Exception(e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -21,7 +21,6 @@ import java.math.BigInteger;
 
 import ee.jakarta.tck.persistence.core.versioning.Member;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import jakarta.persistence.PersistenceUnitUtil;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private final Employee empRef[] = new Employee[2];
 
@@ -274,18 +273,6 @@ public class Client extends PMClientBase {
 		}
 		if (!pass) {
 			throw new Exception("getClassTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.persistenceUtil;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.PersistenceUtil;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -79,15 +78,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +44,7 @@ import jakarta.persistence.TransactionRequiredException;
 import jakarta.persistence.TypedQuery;
 
 public class Client1 extends PMClientBase {
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	private final Employee empRef[] = new Employee[21];
 
@@ -4363,15 +4362,4 @@ public class Client1 extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.query.apitests;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	final Department deptRef[] = new Department[5];
 
@@ -57,16 +56,6 @@ public class Client2 extends PMClientBase {
 			logger.log(Logger.Level.ERROR, "Unexpected Exception caught in Setup: ", e);
 			throw new Exception("Setup failed:", e);
 
-		}
-	}
-
-	@AfterEach
-	public void cleanupNoData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "in cleanupNoData");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3.java
@@ -24,7 +24,6 @@ import java.text.DecimalFormat;
 import java.util.Collection;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Query;
 
 public class Client3 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	private final Employee empRef[] = new Employee[21];
 
@@ -71,16 +70,6 @@ public class Client3 extends PMClientBase {
 			logger.log(Logger.Level.ERROR, "Unexpected Exception caught in Setup: ", e);
 			throw new Exception("Setup failed:", e);
 
-		}
-	}
-
-	@AfterEach
-	public void cleanupNoData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "in cleanupNoData");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,16 +62,6 @@ public class Client4 extends PMClientBase {
             logger.log(Logger.Level.ERROR, "Unexpected Exception caught in Setup: ", e);
             throw new Exception("Setup failed:", e);
 
-        }
-    }
-
-    @AfterEach
-    public void cleanupNoData() throws Exception {
-        try {
-            logger.log(Logger.Level.TRACE, "in cleanupNoData");
-            super.cleanup();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1.java
@@ -35,7 +35,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client1 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2.java
@@ -36,7 +36,7 @@ import jakarta.persistence.FlushModeType;
 
 public class Client2 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client2.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3.java
@@ -31,7 +31,7 @@ import ee.jakarta.tck.persistence.common.schema30.UtilProductData;
 
 public class Client3 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client3.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1.java
@@ -36,7 +36,7 @@ import jakarta.persistence.Query;
 
 public class Client1 extends UtilOrderData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client2 extends UtilCustomerData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client3 extends UtilAliasData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4.java
@@ -34,7 +34,7 @@ import jakarta.persistence.Query;
 
 public class Client4 extends UtilProductData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5.java
@@ -28,7 +28,7 @@ import ee.jakarta.tck.persistence.common.schema30.UtilPhoneData;
 
 public class Client5 extends UtilPhoneData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client5.class.getName());
+	private static final Logger logger = System.getLogger(Client5.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6.java
@@ -31,7 +31,7 @@ import ee.jakarta.tck.persistence.common.schema30.UtilDepartmentEmployeeData;
 
 public class Client6 extends UtilDepartmentEmployeeData {
 
-	private static final Logger logger = (Logger) System.getLogger(Client6.class.getName());
+	private static final Logger logger = System.getLogger(Client6.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 		String pkgNameWithoutSuffix = Client1.class.getPackageName();

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	protected final Employee empRef[] = new Employee[5];
 
@@ -692,16 +691,6 @@ public class Client1 extends PMClientBase {
 			throw new Exception("getParametersNoParametersTest failed");
 		}
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.Query;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	protected final Employee empRef[] = new Employee[5];
 
@@ -238,18 +237,6 @@ public class Client2 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("createDepartmentEmployeeData failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupEmployee() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Client.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final Address aRef[] = new Address[5];
 
@@ -1285,15 +1284,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Company.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/Company.java
@@ -35,7 +35,7 @@ import jakarta.persistence.OneToOne;
 
 @Entity
 public class Company implements java.io.Serializable {
-	private static final Logger logger = (Logger) System.getLogger(Company.class.getName());
+	private static final Logger logger = System.getLogger(Company.class.getName());
 
 	private long companyId;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/Client.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public JavaArchive createDeployment() throws Exception {
 
@@ -173,15 +172,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/Client.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -157,15 +156,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -194,15 +193,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.relationship.bidironexone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -118,16 +117,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static Address aRef[] = new Address[5];
 
@@ -1181,15 +1180,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Company.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Company.java
@@ -36,7 +36,7 @@ import jakarta.persistence.OneToOne;
 @Entity
 public class Company implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private long companyId;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Project.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/Project.java
@@ -37,7 +37,7 @@ import jakarta.persistence.OneToOne;
 @Entity
 public class Project implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(Project.class.getName());
+	private static final Logger logger = System.getLogger(Project.class.getName());
 
 	// Instance Variables
 	private long projId;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/Client.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final XAddress aRef[] = new XAddress[5];
 
@@ -1181,18 +1180,6 @@ public class Client extends PMClientBase {
 		}
 		getEntityTransaction().commit();
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/XCompany.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/XCompany.java
@@ -29,7 +29,7 @@ import java.util.Collection;
 
 public class XCompany implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(XCompany.class.getName());
+	private static final Logger logger = System.getLogger(XCompany.class.getName());
 
 	private long xCompanyId;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/XProject.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/XProject.java
@@ -30,7 +30,7 @@ import java.util.Collection;
 
 public class XProject implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(XProject.class.getName());
+	private static final Logger logger = System.getLogger(XProject.class.getName());
 
 	// Instance Variables
 	private long xProjId;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/Client.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -162,15 +161,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.relationship.unimanyxone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -145,15 +144,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/Client.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Vector;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -135,15 +134,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.core.relationship.unionexone;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -105,15 +104,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.types.auto;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private DataTypes d0;
 
@@ -488,18 +487,6 @@ public class Client extends PMClientBase {
 			}
 		}
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
@@ -86,25 +86,25 @@ public class Client extends PMClientBase {
     private static final Instant INSTANT_DEF = Instant.ofEpochSecond(0);
 
     /** Instant constant. */
-    private static final Instant INSTANT = Instant.now();
+    private static final Instant INSTANT = Instant.parse("2024-06-15T10:30:00Z");
 
     /** Default LocalDate constant. */
     private static final LocalDate LOCAL_DATE_DEF = LocalDate.of(1970, 1, 1);
 
     /** LocalDate constant. */
-    private static final LocalDate LOCAL_DATE = LocalDate.now();
+    private static final LocalDate LOCAL_DATE = LocalDate.of(2024, 6, 15);
 
     /** Default LocalTime constant. */
     private static final LocalTime LOCAL_TIME_DEF = LocalTime.of(0, 0, 0);
 
     /** LocalTime constant. */
-    private static final LocalTime LOCAL_TIME = LocalTime.now().truncatedTo(ChronoUnit.MINUTES);
+    private static final LocalTime LOCAL_TIME = LocalTime.of(10, 30);
 
     /** Default LocalDateTime constant. */
     private static final LocalDateTime LOCAL_DATE_TIME_DEF = LocalDateTime.of(1970, 1, 1, 0, 0, 0);
 
     /** LocalDateTime constant. */
-    private static final LocalDateTime LOCAL_DATE_TIME = initLocalDateTime();
+    private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.of(2024, 6, 15, 10, 30, 0);
 
     /** Default OffsetTime constant. */
     private static final OffsetTime OFFSET_TIME_DEF = OffsetTime.of(LOCAL_TIME_DEF, ZoneOffset.ofHours(1));
@@ -123,7 +123,7 @@ public class Client extends PMClientBase {
     private static final Year YEAR_DEF = Year.of(0);
 
     /** Year constant. */
-    private static final Year YEAR = Year.now();
+    private static final Year YEAR = Year.of(2024);
 
     private static final DateTimeEntity[] entities = {
             new DateTimeEntity(1L, INSTANT_DEF, LOCAL_DATE, LOCAL_TIME_DEF, LOCAL_DATE_TIME_DEF, OFFSET_TIME_DEF,
@@ -140,12 +140,6 @@ public class Client extends PMClientBase {
                     OFFSET_DATE_TIME_DEF, YEAR_DEF),
             new DateTimeEntity(7L, INSTANT_DEF, LOCAL_DATE_DEF, LOCAL_TIME_DEF, LOCAL_DATE_TIME_DEF, OFFSET_TIME_DEF,
                     OFFSET_DATE_TIME_DEF, YEAR)};
-
-    // Databases precision is usually not nanoseconds. Truncate to miliseconds.
-    private static LocalDateTime initLocalDateTime() {
-        final LocalDateTime value = LocalDateTime.now();
-        return value.withNano((value.getNano() / 1000000) * 1000000);
-    }
 
     /*
      * @testName: dateTimeTest

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client extends PMClientBase {
 
-    private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+    private static final Logger logger = System.getLogger(Client.class.getName());
 
     private static final long serialVersionUID = 22L;
 
@@ -81,23 +80,6 @@ public class Client extends PMClientBase {
     @Override
     protected boolean dropCreateSchemaOnStartByDefault() {
         return false;
-    }
-
-    @Override
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            logger.log(Logger.Level.INFO, "Cleanup: Jakarta Persistence 2.2 Java 8 date and time types test");
-            Properties props = getPersistenceUnitProperties();
-            props.put("jakarta.persistence.schema-generation.database.action", "drop");
-            displayProperties(props);
-            logger.log(Logger.Level.INFO, " - executing persistence schema cleanup");
-            Persistence.generateSchema(getPersistenceUnitName(), props);
-            closeEMAndEMF();
-            super.cleanup();
-        } finally {
-            removeTestJarFromCP();
-        }
     }
 
     /** Default Instant constant. */

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/Client.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.Query;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private DataTypes d1;
 
@@ -1242,15 +1241,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client.java
@@ -22,40 +22,14 @@ package ee.jakarta.tck.persistence.core.types.generator;
 
 import java.lang.System.Logger;
 
-import org.junit.jupiter.api.AfterEach;
-
 import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	protected boolean supports_sequence = false;
 
 	public Client() {
 	}
-
-	protected void createSequenceGenerator() {
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("CREATE SEQUENCE SEQGENERATOR START WITH 10").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while creating seq:", e);
-		}
-
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client1 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	private DataTypes d0;
 
@@ -72,7 +72,6 @@ public class Client1 extends Client {
 				supports_sequence = Boolean.parseBoolean(s);
 				logger.log(Logger.Level.INFO, "db.supports.sequence:" + supports_sequence);
 				if (supports_sequence) {
-					createSequenceGenerator();
 					removeTestData();
 					createTestData();
 				}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client2 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	private DataTypes2 d10;
 
@@ -59,7 +59,6 @@ public class Client2 extends Client {
 				supports_sequence = Boolean.parseBoolean(s);
 				logger.log(Logger.Level.INFO, "db.supports.sequence:" + supports_sequence);
 				if (supports_sequence) {
-					createSequenceGenerator();
 					removeTestData();
 					createDataTypes2Data();
 				}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client3 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+	private static final Logger logger = System.getLogger(Client3.class.getName());
 
 	private DataTypes3 d11;
 
@@ -61,7 +61,6 @@ public class Client3 extends Client {
 				supports_sequence = Boolean.parseBoolean(s);
 				logger.log(Logger.Level.INFO, "db.supports.sequence:" + supports_sequence);
 				if (supports_sequence) {
-					createSequenceGenerator();
 					removeTestData();
 					createDataTypes3Data();
 				}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class Client4 extends Client {
 
-	private static final Logger logger = (Logger) System.getLogger(Client4.class.getName());
+	private static final Logger logger = System.getLogger(Client4.class.getName());
 
 	private DataTypes4 d12;
 
@@ -61,7 +61,6 @@ public class Client4 extends Client {
 				supports_sequence = Boolean.parseBoolean(s);
 				logger.log(Logger.Level.INFO, "db.supports.sequence:" + supports_sequence);
 				if (supports_sequence) {
-					createSequenceGenerator();
 					removeTestData();
 					createDataTypes4Data();
 				}

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.core.types.primarykey.compound;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final CompoundPK refPK1 = new CompoundPK(1, "cof0001", 1.0F);
 
@@ -336,18 +335,6 @@ public class Client extends PMClientBase {
 		}
 
 		/* testCompoundPK3 pass */
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "PKEY")
 public class TestBean implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(TestBean.class.getName());
+	private static final Logger logger = System.getLogger(TestBean.class.getName());
 
 	private CompoundPK compoundPK;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean2.java
@@ -33,7 +33,7 @@ import jakarta.persistence.Table;
 @Table(name = "PKEY")
 public class TestBean2 implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(TestBean2.class.getName());
+	private static final Logger logger = System.getLogger(TestBean2.class.getName());
 
 	private Integer pmIDInteger;
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/TestBean3.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "PKEY")
 public class TestBean3 implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(TestBean3.class.getName());
+	private static final Logger logger = System.getLogger(TestBean3.class.getName());
 
 	@Id
 	private Integer pmIDInteger;

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1.java
@@ -21,7 +21,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import ee.jakarta.tck.persistence.core.types.common.Grade;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	private DataTypes d1;
 
@@ -928,15 +927,4 @@ public class Client1 extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import ee.jakarta.tck.persistence.core.types.common.Grade;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	public Client2() {
 	}
@@ -51,7 +50,7 @@ public class Client2 extends PMClientBase {
 		try {
 			super.setup();
 			createDeployment();
-			removeCustTestData();
+			removeTestData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
@@ -123,38 +122,4 @@ public class Client2 extends PMClientBase {
 
 	// Methods used for Tests
 
-	@AfterEach
-	public void cleanupCust() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeCustTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
-
-	private void removeCustTestData() {
-		logger.log(Logger.Level.TRACE, "removeCustTestData");
-		if (getEntityTransaction().isActive()) {
-			getEntityTransaction().rollback();
-		}
-		try {
-			getEntityTransaction().begin();
-			getEntityManager().createNativeQuery("DELETE FROM CUST_TABLE").executeUpdate();
-			getEntityManager().createNativeQuery("DELETE FROM PHONES").executeUpdate();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception re) {
-				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
-			}
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/Client.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.math.BigInteger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -157,15 +156,4 @@ public class Client extends PMClientBase {
 			throw new Exception("versionTest1 failed");
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/A.java
@@ -32,7 +32,7 @@ import jakarta.persistence.Table;
 @Table(name = "AEJB_1XM_BI_BTOB")
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/B.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/B.java
@@ -31,7 +31,7 @@ import jakarta.persistence.Table;
 @Table(name = "BEJB_1XM_BI_BTOB")
 public class B implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(B.class.getName());
+	private static final Logger logger = System.getLogger(B.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/Client.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -1029,16 +1028,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa22.generators.tablegenerators;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -109,18 +108,6 @@ public class Client extends PMClientBase {
 
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/Client.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.TypedQuery;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -309,18 +308,6 @@ public class Client extends PMClientBase {
 			}
 		}
 
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
 	}
 
 	private void assertTrue(boolean condition, String message) throws Exception {

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.sql.Date;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
  */
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -187,18 +186,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception rolling back TX:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/convert/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/convert/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa22.repeatable.convert;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -124,15 +123,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/Client.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.List;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -129,15 +128,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/Client.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityManager;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -256,15 +255,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ import jakarta.persistence.EntityGraph;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -66,17 +65,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupEmployeeData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa22.repeatable.namednativequery;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -27,7 +26,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -140,18 +139,6 @@ public class Client extends PMClientBase {
 			} catch (Exception re) {
 				logger.log(Logger.Level.ERROR, "Unexpected Exception in rollback:", re);
 			}
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,7 @@ import jakarta.persistence.StoredProcedureQuery;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -86,17 +85,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "Cleanup data");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/Client.java
@@ -299,11 +299,11 @@ public class Client extends PMClientBase {
 			final Date d5 = getUtilDate();
 
 			emp0 = new Employee(1, "Alan", "Frechette", d1, (float) 35000.0);
-			empRef.add(emp0);
-			empRef.add(new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0));
-			empRef.add(new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0));
-			empRef.add(new Employee(4, "Robert", "Bissett", d4, (float) 55000.0));
-			empRef.add(new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
+			empRef = List.of(emp0,
+					new Employee(2, "Arthur", "Frechette", d2, (float) 35000.0),
+					new Employee(3, "Shelly", "McGowan", d3, (float) 50000.0),
+					new Employee(4, "Robert", "Bissett", d4, (float) 55000.0),
+					new Employee(5, "Stephen", "DMilla", d5, (float) 25000.0));
 			for (Employee e : empRef) {
 				if (e != null) {
 					getEntityManager().persist(e);

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/generators/sequencegenerators/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/generators/sequencegenerators/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -229,18 +228,6 @@ public class Client extends PMClientBase {
 		logger.log(Logger.Level.TRACE, "pass4:" + pass4);
 		if (!pass1a || !pass1b || !pass2a || !pass2b || !pass3 || !pass4) {
 			throw new Exception("sequenceGeneratorTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/repeatable/secondarytable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/se/repeatable/secondarytable/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa22.se.repeatable.secondarytable;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -154,15 +153,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/configuration/Client.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.PersistenceConfiguration;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,11 +42,6 @@ public class Client extends PMClientBase {
     public void setup() throws Exception {
         super.setup();
         createDeployment();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        removeTestJarFromCP();
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/entitytype/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
 import jakarta.persistence.metamodel.EntityType;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,19 +48,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/functions/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.criteria.LocalDateField;
 import jakarta.persistence.criteria.LocalDateTimeField;
 import jakarta.persistence.criteria.Root;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,19 +49,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/list/Client.java
@@ -28,7 +28,6 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,19 +49,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/criteria/setops/Client.java
@@ -23,7 +23,6 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaSelect;
 import jakarta.persistence.criteria.Root;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,19 +46,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entitymanager/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Query;
 import jakarta.persistence.Timeout;
 import jakarta.persistence.TypedQuery;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,19 +45,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/entityresult/Client.java
@@ -22,7 +22,6 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.SqlResultSetMapping;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +41,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/enumeratedvalue/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.enumeratedvalue;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +39,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.Subgraph;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,19 +46,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/graph/advanced/Client.java
@@ -24,7 +24,6 @@ import jakarta.persistence.metamodel.ListAttribute;
 import jakarta.persistence.metamodel.MapAttribute;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,19 +50,6 @@ public class Client extends PMClientBase {
         createDeployment();
         getEntityManager();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/jpql/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.jpql;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +43,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/metamodel/Client.java
@@ -25,7 +25,6 @@ import jakarta.persistence.TypedQueryReference;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.StaticMetamodel;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -57,19 +56,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/namednativequery/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.namednativequery;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,19 +38,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/query/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.query;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,19 +42,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/recordpk/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/recordpk/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.recordpk;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,19 +44,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/records/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.records;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +39,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/schemamanager/Client.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.SchemaManager;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,19 +40,6 @@ public class Client extends PMClientBase {
         createDeployment();
         getEntityManager();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/singleresult/Client.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +41,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/statictype/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.statictype;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +43,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/transaction/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.transaction;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,19 +38,6 @@ public class Client extends PMClientBase {
         super.setup();
         createDeployment();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/uuid/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.uuid;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,19 +38,6 @@ public class Client extends PMClientBase {
         super.setup();
         createDeployment();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/version/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.version;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,19 +42,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa32/year/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa32.year;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -42,19 +41,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/callbacks/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/callbacks/Client.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,19 +52,6 @@ public class Client extends PMClientBase {
         getEntityManager();
         removeTestData();
         CallbackEventLog.reset();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteria/specialized/Client.java
@@ -40,7 +40,6 @@ import jakarta.persistence.metamodel.SetAttribute;
 import jakarta.persistence.metamodel.TemporalAttribute;
 import jakarta.persistence.metamodel.TextAttribute;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -68,19 +67,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteriastring/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/criteriastring/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.criteria.CriteriaStatement;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,19 +50,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**
@@ -320,6 +306,7 @@ public class Client extends PMClientBase {
     }
 
     private void createTestData() {
+        getEntityManager().clear();
         EntityTransaction transaction = getEntityTransaction();
         transaction.begin();
         getEntityManager().persist(new CriteriaStringBook(1, "Alpha"));

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/emflistener/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/emflistener/Client.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityListenerRegistration;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PostPersist;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +43,6 @@ public class Client extends PMClientBase {
         createDeployment();
         getEntityManager();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entityagent/Client.java
@@ -27,7 +27,6 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.OptimisticLockException;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -54,19 +53,6 @@ public class Client extends PMClientBase {
         createDeployment();
         getEntityManager();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entitytypegraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/entitytypegraph/Client.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.metamodel.EntityType;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +43,6 @@ public class Client extends PMClientBase {
         createDeployment();
         getEntityManager();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchdefaults/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchdefaults/Client.java
@@ -22,7 +22,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceConfiguration;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,11 +46,6 @@ public class Client extends PMClientBase {
     public void setup() throws Exception {
         super.setup();
         createDeployment();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        removeTestJarFromCP();
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/fetchoption/Client.java
@@ -25,7 +25,6 @@ import jakarta.persistence.FetchOption;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Persistence;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,19 +50,6 @@ public class Client extends PMClientBase {
         getEntityManager();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/find/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/find/Client.java
@@ -27,7 +27,6 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.TransactionRequiredException;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -50,19 +49,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/jpql/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/jpql/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa40.jpql;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,19 +40,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/lockscope/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/lockscope/Client.java
@@ -23,7 +23,6 @@ import jakarta.persistence.LockModeType;
 import jakarta.persistence.PessimisticLockScope;
 import jakarta.persistence.TypedQuery;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -45,19 +44,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nameddescriptor/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nameddescriptor/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa40.nameddescriptor;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,19 +38,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/Client.java
@@ -23,7 +23,6 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.Subgraph;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,19 +46,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/SharedNameClient.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedgraph/SharedNameClient.java
@@ -22,7 +22,6 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.Subgraph;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,19 +47,6 @@ public class SharedNameClient extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedqueryregistration/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/namedqueryregistration/Client.java
@@ -26,7 +26,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,19 +52,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nonnull/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/nonnull/Client.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.metamodel.EntityType;
 import jakarta.persistence.metamodel.SingularAttribute;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,19 +40,6 @@ public class Client extends PMClientBase {
         super.setup();
         createDeployment();
         removeTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/parameters/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/parameters/Client.java
@@ -30,7 +30,6 @@ import jakarta.persistence.criteria.ParameterExpression;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.metamodel.Type;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -55,19 +54,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/persistenceconfiguration/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/persistenceconfiguration/Client.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.PersistenceConfiguration;
 import jakarta.persistence.SchemaManagementAction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -53,15 +52,6 @@ public class Client extends PMClientBase {
         schemaDirectory = Files.createTempDirectory("jpa40-export-schema");
         createScript = schemaDirectory.resolve("create.sql");
         dropScript = schemaDirectory.resolve("drop.sql");
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestJarFromCP();
-        } finally {
-            deleteSchemaScripts();
-        }
     }
 
     @Override

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/queryflush/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/queryflush/Client.java
@@ -22,7 +22,6 @@ import jakarta.persistence.FlushModeType;
 import jakarta.persistence.Query;
 import jakarta.persistence.QueryFlushMode;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,19 +42,6 @@ public class Client extends PMClientBase {
         getEntityManager();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/querygraph/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/querygraph/Client.java
@@ -21,7 +21,6 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.Persistence;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +43,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/resultcount/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/resultcount/Client.java
@@ -20,7 +20,6 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.TypedQuery;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +39,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/schemamanager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/schemamanager/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa40.schemamanager;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.*;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -48,15 +47,6 @@ public class Client extends PMClientBase {
         super.setup();
         createDeployment();
         createLoadScript();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestJarFromCP();
-        } finally {
-            deleteLoadScript();
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/sqlresultmapping/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/sqlresultmapping/Client.java
@@ -29,7 +29,6 @@ import jakarta.persistence.sql.FieldMapping;
 import jakarta.persistence.sql.ResultSetMapping;
 import jakarta.persistence.sql.TupleMapping;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -66,19 +65,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/statement/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/statement/Client.java
@@ -25,7 +25,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.criteria.Root;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,19 +46,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/versioning/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/versioning/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa40.versioning;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +39,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/xmlstatement/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/jpa40/xmlstatement/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.jpa40.xmlstatement;
 import ee.jakarta.tck.persistence.common.PMClientBase;
 import jakarta.persistence.EntityTransaction;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,19 +39,6 @@ public class Client extends PMClientBase {
         createDeployment();
         removeTestData();
         createTestData();
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            removeTestData();
-        } finally {
-            try {
-                super.cleanup();
-            } finally {
-                removeTestJarFromCP();
-            }
-        }
     }
 
     /**

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/inherit/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/inherit/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.se.cache.inherit;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -247,15 +246,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/all/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/all/Client.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Properties jpaprops = new Properties();
 
@@ -625,15 +624,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/disableselective/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/disableselective/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.se.cache.xml.disableselective;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -135,15 +134,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/enableselective/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/enableselective/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.se.cache.xml.enableselective;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -148,15 +147,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/none/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/cache/xml/none/Client.java
@@ -19,7 +19,6 @@ package ee.jakarta.tck.persistence.se.cache.xml.none;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import jakarta.persistence.EntityTransaction;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	public Client() {
 	}
@@ -117,15 +116,4 @@ public class Client extends PMClientBase {
 
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/descriptor/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/descriptor/Client.java
@@ -23,7 +23,6 @@ package ee.jakarta.tck.persistence.se.descriptor;
 import java.lang.System.Logger;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +30,7 @@ import ee.jakarta.tck.persistence.common.PMClientBase;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final B bRef[] = new B[5];
 
@@ -119,14 +118,4 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/A.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/A.java
@@ -37,7 +37,7 @@ import jakarta.persistence.TemporalType;
 @Cacheable(true)
 public class A implements java.io.Serializable {
 
-	private static final Logger logger = (Logger) System.getLogger(A.class.getName());
+	private static final Logger logger = System.getLogger(A.class.getName());
 
 	// ===========================================================
 	// instance variables

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Client.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,7 @@ import jakarta.persistence.criteria.Root;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	Properties props = new Properties();
 
@@ -83,17 +82,6 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupData() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanupData");
-			removeTestData();
-			cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Order.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManager/Order.java
@@ -69,15 +69,15 @@ public class Order implements java.io.Serializable {
 		this.total = total;
 	}
 
-	public String getdescription() {
+	public String getDescription() {
 		return description;
 	}
 
-	public void setdescription(String description) {
+	public void setDescription(String description) {
 		this.description = description;
 	}
 
 	public String toString() {
-		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getdescription();
+		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getDescription();
 	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManagerFactory/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManagerFactory/Client1.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -29,7 +28,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	Properties props = null;
 
@@ -54,15 +53,6 @@ public class Client1 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanupNoData() throws Exception {
-		try {
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManagerFactory/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/entityManagerFactory/Client2.java
@@ -20,7 +20,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -33,7 +32,7 @@ import jakarta.persistence.PersistenceException;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	Properties props = null;
 
@@ -58,14 +57,6 @@ public class Client2 extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/pluggability/contracts/resource_local/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/pluggability/contracts/resource_local/Client.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +46,7 @@ import jakarta.persistence.spi.PersistenceUnitInfo;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 1L;
 
@@ -673,16 +672,9 @@ public class Client extends PMClientBase {
 		puInfo = emfImpl.puInfo;
 	}
 
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			logger.log(Logger.Level.TRACE, "calling super.cleanup");
-			super.cleanup();
-			removeTestJarFromCP();
-		} finally {
-			removePluggabilityJarFromCP();
-		}
-
+	@Override
+	public void removeTestJarFromCP() throws Exception {
+		super.removeTestJarFromCP();
+		removePluggabilityJarFromCP();
 	}
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client1.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +38,7 @@ import jakarta.persistence.SynchronizationType;
 
 public class Client1 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+	private static final Logger logger = System.getLogger(Client1.class.getName());
 
 	private EntityManager entityManager;
 
@@ -810,15 +809,6 @@ public class Client1 extends PMClientBase {
 		if (!pass1 || !pass2) {
 			throw new Exception("createEntityManagerSynchronizationTypeMapIllegalStateExceptionTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		logger.log(Logger.Level.TRACE, "cleanup");
-		removeTestData();
-		logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-		super.cleanup();
-		removeTestJarFromCP();
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/resource_local/Client2.java
@@ -24,7 +24,6 @@ import java.lang.System.Logger;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,7 @@ import jakarta.persistence.SynchronizationType;
 
 public class Client2 extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+	private static final Logger logger = System.getLogger(Client2.class.getName());
 
 	private EntityManager entityManager;
 
@@ -104,13 +103,6 @@ public class Client2 extends PMClientBase {
 		if (!pass1 || !pass2) {
 			throw new Exception("createEntityManagerSynchronizationTypeIllegalStateExceptionTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanupOnly() throws Exception {
-		logger.log(Logger.Level.TRACE, "cleanupOnly");
-		super.cleanup();
-		removeTestJarFromCP();
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/discriminatorColumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/discriminatorColumn/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 
@@ -204,19 +203,6 @@ public class Client extends PMClientBase {
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("discriminatorColumnTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/enumerated/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/enumerated/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 
@@ -203,18 +202,6 @@ public class Client extends PMClientBase {
 		logger.log(Logger.Level.TRACE, "pass4:" + pass4);
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("enumeratedTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/id/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/id/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 
@@ -203,18 +202,6 @@ public class Client extends PMClientBase {
 		logger.log(Logger.Level.TRACE, "pass4:" + pass4);
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("idTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/index/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/index/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -286,18 +285,6 @@ public class Client extends PMClientBase {
 																	// !pass2d ||
 				!pass3 || !pass4) {
 			throw new Exception("indexTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/joinTable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/joinTable/Client.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -339,19 +338,6 @@ public class Client extends PMClientBase {
 				|| !pass3 || !pass4 || !pass5) {
 			throw new Exception("joinTableTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/orderColumn/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/orderColumn/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 import jakarta.persistence.TypedQuery;
 
 public class Client extends PMClientBase {
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -285,19 +284,6 @@ public class Client extends PMClientBase {
 		if (!pass1a || !pass1b || !pass1c || !pass2a || !pass2b || !pass2c || !pass3 || !pass4 || !pass5) {
 			throw new Exception("orderColumnTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/secondaryTable/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/secondaryTable/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -241,19 +240,6 @@ public class Client extends PMClientBase {
 		if (!pass1a || !pass1b || !pass1c || !pass2a || !pass2b || !pass2c || !pass3 || !pass4) {
 			throw new Exception("secondaryTableTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/sequenceGenerator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/sequenceGenerator/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -233,19 +232,6 @@ public class Client extends PMClientBase {
 		if (!pass1a || !pass1b || !pass2a || !pass2b || !pass3 || !pass4) {
 			throw new Exception("sequenceGeneratorTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/table/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/table/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 
@@ -198,19 +197,6 @@ public class Client extends PMClientBase {
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("tableTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/tableGenerator/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/tableGenerator/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -224,18 +223,6 @@ public class Client extends PMClientBase {
 		logger.log(Logger.Level.TRACE, "pass4:" + pass4);
 		if (!pass1a || !pass1b || !pass1c || !pass2a || !pass3 || !pass4) {
 			throw new Exception("tableGeneratorTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData(true);
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/temporal/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/temporal/Client.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +33,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 
@@ -207,18 +206,6 @@ public class Client extends PMClientBase {
 		logger.log(Logger.Level.TRACE, "pass4:" + pass4);
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("temporalTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/uniqueConstraint/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/uniqueConstraint/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	private static final long serialVersionUID = 22L;
 
@@ -224,18 +223,6 @@ public class Client extends PMClientBase {
 		if (!pass1a || !pass1b ||
 		/* !pass2a || */ !pass2b || !pass3 || !pass4) {
 			throw new Exception("uniqueConstraintTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/version/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/annotations/version/Client.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 	String sTestCase = "jpa_se_schemaGeneration_annotations_version";
@@ -205,19 +204,6 @@ public class Client extends PMClientBase {
 		if (!pass1 || !pass2 || !pass3 || !pass4) {
 			throw new Exception("versionTest failed");
 		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
-		}
-
 	}
 
 }

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/scripts/Client.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/se/schemaGeneration/scripts/Client.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +43,7 @@ import jakarta.persistence.Persistence;
 
 public class Client extends PMClientBase {
 
-	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
+	private static final Logger logger = System.getLogger(Client.class.getName());
 
 	String schemaGenerationDir = null;
 	String sTestCase = "jpa_se_schemaGeneration_scripts";
@@ -1118,18 +1117,6 @@ public class Client extends PMClientBase {
 		}
 		if (!pass1 || !pass2 || !pass3) {
 			throw new Exception("executeDropScriptReaderTest failed");
-		}
-	}
-
-	@AfterEach
-	public void cleanup() throws Exception {
-		try {
-			logger.log(Logger.Level.TRACE, "cleanup");
-			removeTestData();
-			logger.log(Logger.Level.TRACE, "cleanup complete, calling super.cleanup");
-			super.cleanup();
-		} finally {
-			removeTestJarFromCP();
 		}
 	}
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client1.java
@@ -23,7 +23,6 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import jakarta.validation.groups.Default;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +32,7 @@ import static ee.jakarta.tck.persistence.common.validation.PersistenceTckValidat
 
 public class Client1 extends PMClientBase {
 
-    private static final Logger logger = (Logger) System.getLogger(Client1.class.getName());
+    private static final Logger logger = System.getLogger(Client1.class.getName());
 
     public Client1() {
     }
@@ -57,16 +56,6 @@ public class Client1 extends PMClientBase {
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception: ", e);
             throw new Exception("Setup failed:", e);
-        }
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            logger.log(Logger.Level.TRACE, "cleanupData");
-            removeTestData();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client2.java
@@ -22,7 +22,6 @@ import jakarta.persistence.EntityAgent;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Persistence;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +29,7 @@ import java.lang.System.Logger;
 
 public class Client2 extends PMClientBase {
 
-    private static final Logger logger = (Logger) System.getLogger(Client2.class.getName());
+    private static final Logger logger = System.getLogger(Client2.class.getName());
 
     public Client2() {
     }
@@ -54,16 +53,6 @@ public class Client2 extends PMClientBase {
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception: ", e);
             throw new Exception("Setup failed:", e);
-        }
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            logger.log(Logger.Level.TRACE, "cleanupData");
-            removeTestData();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 

--- a/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
+++ b/tck/spec-tests/src/main/java/ee/jakarta/tck/persistence/validation/Client3.java
@@ -24,7 +24,6 @@ import jakarta.persistence.Persistence;
 import jakarta.persistence.PersistenceException;
 import jakarta.validation.groups.Default;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +34,7 @@ import static ee.jakarta.tck.persistence.common.validation.PersistenceTckValidat
 
 public class Client3 extends PMClientBase {
 
-    private static final Logger logger = (Logger) System.getLogger(Client3.class.getName());
+    private static final Logger logger = System.getLogger(Client3.class.getName());
 
     public Client3() {
     }
@@ -59,16 +58,6 @@ public class Client3 extends PMClientBase {
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Exception: ", e);
             throw new Exception("Setup failed:", e);
-        }
-    }
-
-    @AfterEach
-    public void cleanup() throws Exception {
-        try {
-            logger.log(Logger.Level.TRACE, "cleanupData");
-            removeTestData();
-        } finally {
-            removeTestJarFromCP();
         }
     }
 
@@ -224,6 +213,5 @@ public class Client3 extends PMClientBase {
             validatorFactory.assertNoValidationCalls();
         }
     }
-
 
 }


### PR DESCRIPTION
The switch to `Lifecycle.PER_CLASS` removes the unnecessary factory setup + DDL work and that results in:
from
```
2248 tests
   in 310 test classes
   executed in 1 project
   in 2m 47.585s serial time
   and 2m 50.231s task execution time
```
to:
```
  2248 tests
   in 310 test classes
   executed in 1 project
   in 1m 3.965s serial time
   and 1m 6.150s task execution time
```

would be a bit slower on CIs, but should still improve execution time.

* There was a date-time test that was "execution-time-sensitive" in the sense that it was relying on setting up test data with  `.now()`, which might be unpredictable ... 
* A few test classes were silently failing data setup or checks -- made some changes there to just use asserts or to rely on DDL created by the provider before applying the stored procedures script -- there were some tests that were not creating necessary tables 😖 
* and last but not least ... removed the `(Logger) ` cast 🫣 


> [!IMPORTANT]
> Tests are now using per-class lifecycle, so it's a single test class instance to run all the test methods in that class, which means that if tests are relying on instance data, it has to be managed with ^ in mind.
