### PR TITLE
two minor additions to Javadoc

### DIFF
--- a/api/src/main/java/jakarta/persistence/AttributeConverter.java
+++ b/api/src/main/java/jakarta/persistence/AttributeConverter.java
@@ -69,6 +69,8 @@ package jakarta.persistence;
  *
  * @see Converter
  * @see Convert#converter
+ *
+ * @since 2.1
  */
 public interface AttributeConverter<X,Y> {
 

--- a/api/src/main/java/jakarta/persistence/Embedded.java
+++ b/api/src/main/java/jakarta/persistence/Embedded.java
@@ -27,7 +27,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * value is an instance of an embeddable class. The embeddable 
  * class must be annotated as {@link Embeddable}.
  *
- * <p> The {@link AttributeOverride}, {@link AttributeOverrides},
+ * <p>This annotation is not usually required. If the declared
+ * type of a field or property is annotated {@code Embeddable},
+ * the field or property is automatically treated as if it were
+ * annotated {@code Embedded}.
+ *
+ * <p>The {@link AttributeOverride}, {@link AttributeOverrides},
  * {@link AssociationOverride}, and {@link AssociationOverrides}
  * annotations may be used to override mappings declared or
  * defaulted by the embeddable class.


### PR DESCRIPTION
1. make clear that `@Embedded` is optional
2. add a missing `@since` annotation